### PR TITLE
feat: add About section with Allen and BetterGov subpages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -97,7 +98,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -693,7 +693,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1672,7 +1671,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5678,7 +5676,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5688,7 +5685,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5699,7 +5695,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5776,7 +5771,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -6073,7 +6067,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6324,7 +6317,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7218,7 +7210,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8103,7 +8094,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8204,7 +8194,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -9155,7 +9144,6 @@
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.575.0.tgz",
       "integrity": "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -10724,7 +10712,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11060,7 +11047,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11070,7 +11056,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11213,7 +11198,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
       "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -11236,7 +11220,6 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
       "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-router": "7.13.1"
       },
@@ -12054,8 +12037,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -12127,7 +12109,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12260,7 +12241,6 @@
       "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
       "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"
       }
@@ -12313,7 +12293,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12628,7 +12607,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12722,7 +12700,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13013,7 +12990,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,15 +7,23 @@ import ScrollToTop from './components/ui/ScrollToTop';
 import Services from './pages/Services';
 import Document from './pages/Document';
 import Government from './pages/Government';
+import About from './pages/about/index';
+import AboutAllen from './pages/about/Allen';
+import AboutBetterGov from './pages/about/BetterGov';
 import { Toaster } from './components/ui/sonner';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+} from 'react-router-dom';
 
 function App() {
   return (
     <HelmetProvider>
       <Router>
         <NuqsAdapter>
-          <div className="min-h-screen flex flex-col">
+          <div className="flex flex-col min-h-screen">
             <Navbar />
             <ScrollToTop />
             <Routes>
@@ -32,6 +40,11 @@ function App() {
                 path="/government/:category/:documentSlug"
                 element={<Document categoryType="government" />}
               />
+              <Route path="/about" element={<About />}>
+                <Route index element={<Navigate to="/about/allen" replace />} />
+                <Route path="allen" element={<AboutAllen />} />
+                <Route path="bettergov" element={<AboutBetterGov />} />
+              </Route>
               <Route path="/:lang/:documentSlug" element={<Document />} />
               <Route path="/:documentSlug" element={<Document />} />
             </Routes>

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -1,0 +1,140 @@
+import { Link } from 'react-router-dom';
+import { Heading } from '../ui/Heading';
+import { Text } from '../ui/Text';
+import yaml from 'js-yaml';
+import allenYaml from '../../data/about_allen.yaml?raw';
+import betterGovYaml from '../../data/about_bettergov.yaml?raw';
+
+interface AllenData {
+  name: string;
+  province: string;
+  description: string;
+}
+
+interface BetterGovData {
+  name: string;
+  description: string;
+}
+
+const allen = yaml.load(allenYaml) as AllenData;
+const bettergov = yaml.load(betterGovYaml) as BetterGovData;
+
+const AboutSection: React.FC = () => {
+  return (
+    <section className="px-6 py-16 bg-gray-50 sm:px-10 lg:px-20 xl:px-30">
+      <div className="mb-10">
+        <Text className="mb-1 text-xs font-bold tracking-widest uppercase text-primary-500 max-w-none">
+          Get to Know Us
+        </Text>
+        <Heading level={2} className="text-gray-900">
+          About Allen &amp; BetterGov
+        </Heading>
+        <Text className="mt-2 text-gray-500 max-w-none">
+          Learn about the municipality behind this website and the volunteer
+          initiative that built it.
+        </Text>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        {/* Allen Card */}
+        <div className="flex flex-col justify-between p-8 transition-all duration-200 bg-white border border-gray-200 shadow-sm rounded-2xl hover:border-primary-300 hover:shadow-md">
+          <div>
+            <div className="inline-flex items-center justify-center w-10 h-10 mb-5 rounded-xl bg-primary-600">
+              <svg
+                className="w-5 h-5 text-white"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z"
+                />
+              </svg>
+            </div>
+            <Heading level={3} className="mb-2 text-gray-900">
+              {allen.name}, {allen.province}
+            </Heading>
+            <Text className="text-sm leading-relaxed text-gray-500 max-w-none">
+              {allen.description}
+            </Text>
+          </div>
+          <Link
+            to="/about/allen"
+            className="inline-flex items-center gap-2 mt-6 text-sm font-semibold transition-colors text-primary-600 hover:text-primary-500"
+          >
+            Learn about Allen
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
+              />
+            </svg>
+          </Link>
+        </div>
+
+        {/* BetterGov Card */}
+        <div className="flex flex-col justify-between p-8 transition-all duration-200 border shadow-sm bg-primary-600 border-primary-700 rounded-2xl hover:bg-primary-500">
+          <div>
+            <div className="inline-flex items-center justify-center w-10 h-10 mb-5 rounded-xl bg-white/20">
+              <svg
+                className="w-5 h-5 text-white"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253M3 12c0 .778.099 1.533.284 2.253"
+                />
+              </svg>
+            </div>
+            <Heading level={3} className="mb-2 text-white">
+              {bettergov.name}
+            </Heading>
+            <Text className="text-sm leading-relaxed text-primary-100 max-w-none">
+              {bettergov.description}
+            </Text>
+          </div>
+          <Link
+            to="/about/bettergov"
+            className="inline-flex items-center gap-2 mt-6 text-sm font-semibold text-white transition-colors hover:text-primary-100"
+          >
+            Learn about BetterGov
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
+              />
+            </svg>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default AboutSection;

--- a/src/data/about_allen.yaml
+++ b/src/data/about_allen.yaml
@@ -19,13 +19,10 @@ history: >
   movement of people between islands.
 
 geography: >
-  Allen occupies a narrow coastal strip along the northern tip of Samar, facing the San
-  Bernardino Strait to the north. The municipality covers 47.60 km² of land, with terrain
-  that transitions from a flat coastal shoreline into rolling hills inland. The strait
-  separates Samar from the Bicol Peninsula of Luzon, making Allen's position geographically
-  significant — it sits at the natural crossing point between two major island groups.
-  The town proper hugs the coast, while its 20 barangays spread inland and along adjacent
-  shorelines.
+  Allen sits at the northern tip of Samar, facing the San Bernardino Strait —
+  the natural crossing point between Luzon and the Visayas. Its 47.60 km² of
+  land spans a flat coastal shoreline that rises into rolling hills inland,
+  with 20 barangays spread along the coast and further inland.
 
 economy: >
   Allen's economy is anchored by fishing and the movement of goods and people through its

--- a/src/data/about_allen.yaml
+++ b/src/data/about_allen.yaml
@@ -17,7 +17,7 @@ history: >
   of people and sea.
 
 geography: >
-  Allen sits at the northern tip of Samar, facing the San Bernardino Strait —
+  Allen sits at the northern tip of Samar, facing the San Bernardino Strait,
   the natural crossing point between Luzon and the Visayas. Its 47.60 km² of
   land spans a flat coastal shoreline that rises into rolling hills inland,
   with 20 barangays spread along the coast and further inland.

--- a/src/data/about_allen.yaml
+++ b/src/data/about_allen.yaml
@@ -6,10 +6,8 @@ province: Northern Samar
 region: Eastern Visayas
 
 description: >
-  Allen is a coastal municipality in Northern Samar and the southern gateway between Luzon
-  and the Visayas. Sitting along the San Bernardino Strait, it is where the ferry from
-  Matnog, Sorsogon arrives — making it one of the most-travelled entry points into the
-  Eastern Visayas region.
+  Allen is a coastal municipality in Northern Samar — the southern gateway between Luzon
+  and the Visayas, where the San Bernardino Strait narrows and every journey south begins.
 
 history: >
   Allen was formally established on December 1, 1863, during the Spanish colonial period,

--- a/src/data/about_allen.yaml
+++ b/src/data/about_allen.yaml
@@ -55,7 +55,7 @@ stats:
     icon: Map
 
   - label: Founded
-    value: December 1, 1863
+    value: Dec. 1, 1863
     sublabel: Date of establishment
     icon: Award
 

--- a/src/data/about_allen.yaml
+++ b/src/data/about_allen.yaml
@@ -1,0 +1,91 @@
+# Allen Municipality Data
+# Non-technical contributors can edit this file to update content on the About Allen page.
+
+name: Allen
+province: Northern Samar
+region: Eastern Visayas
+
+description: >
+  Allen is a coastal municipality in Northern Samar and the southern gateway between Luzon
+  and the Visayas. Sitting along the San Bernardino Strait, it is where the ferry from
+  Matnog, Sorsogon arrives — making it one of the most-travelled entry points into the
+  Eastern Visayas region.
+
+history: >
+  Allen was formally established on December 1, 1863, during the Spanish colonial period,
+  though the area had long been settled by coastal communities who depended on fishing and
+  trade along the strait. Over the centuries, Allen grew from a quiet seaside town into a
+  significant transit point — shaped by colonial administration, war, and the steady
+  movement of people between islands.
+
+geography: >
+  Allen occupies a narrow coastal strip along the northern tip of Samar, facing the San
+  Bernardino Strait to the north. The municipality covers 47.60 km² of land, with terrain
+  that transitions from a flat coastal shoreline into rolling hills inland. The strait
+  separates Samar from the Bicol Peninsula of Luzon, making Allen's position geographically
+  significant — it sits at the natural crossing point between two major island groups.
+  The town proper hugs the coast, while its 20 barangays spread inland and along adjacent
+  shorelines.
+
+economy: >
+  Allen's economy is anchored by fishing and the movement of goods and people through its
+  port. The San Bernardino Strait provides rich fishing grounds, and many residents make
+  their living from the sea — supplying local markets and nearby towns with fresh catch.
+  The RoRo (Roll-on/Roll-off) ferry terminal connecting Allen to Matnog, Sorsogon drives
+  consistent commercial activity: transport services, small trading, eateries, and informal
+  vendors all cluster around the port area. Agriculture — primarily coconut farming and
+  rice — supplements livelihoods further inland.
+
+stats:
+  - label: Population
+    value: "26,527"
+    sublabel: Population (2025 Census)
+    icon: Users
+
+  - label: Barangays
+    value: "20"
+    sublabel: Administrative divisions
+    asOf: As of 2025
+    icon: MapPin
+
+  - label: Land Area
+    value: 47.60 km²
+    sublabel: Total municipal coverage
+    asOf: As of 2025
+    icon: Map
+
+  - label: Founded
+    value: December 1, 1863
+    sublabel: Date of establishment
+    icon: Award
+
+timeline:
+  - year: Pre-1863
+    event: >
+      Coastal Waray settlements along the San Bernardino Strait; fishing and
+      inter-island trade sustain early communities.
+
+  - year: December 1, 1863
+    event: >
+      Allen formally established as a municipality under Spanish colonial
+      administration.
+
+  - year: Early 1900s
+    event: >
+      American period brings new civil governance structure; infrastructure
+      improvements begin across the municipality.
+
+  - year: 1942–1945
+    event: >
+      World War II affects the municipality; post-war reconstruction shapes
+      the modern town center.
+
+  - year: 1950s–1970s
+    event: >
+      Ferry route between Allen and Matnog formalizes, establishing Allen's
+      role as a regional gateway between Luzon and the Visayas.
+
+  - year: Present
+    event: >
+      Allen continues to grow as both a transit hub and a home to over 26,000
+      residents across 20 barangays.

--- a/src/data/about_allen.yaml
+++ b/src/data/about_allen.yaml
@@ -10,11 +10,11 @@ description: >
   and the Visayas, where the San Bernardino Strait narrows and every journey south begins.
 
 history: >
-  Allen was formally established on December 1, 1863, during the Spanish colonial period,
-  though the area had long been settled by coastal communities who depended on fishing and
-  trade along the strait. Over the centuries, Allen grew from a quiet seaside town into a
-  significant transit point — shaped by colonial administration, war, and the steady
-  movement of people between islands.
+  Long before the Spanish arrived, these shores were already home to Austronesian settlers,
+  who called it Minapa-a. Under Spanish colonial rule, the area was formally established as
+  a town and named La Granja, then later renamed Allen under American rule. Through every
+  change of name and ruler, the town has remained a place defined by the constant movement
+  of people and sea.
 
 geography: >
   Allen sits at the northern tip of Samar, facing the San Bernardino Strait —
@@ -57,28 +57,30 @@ stats:
 timeline:
   - year: Pre-1863
     event: >
-      Coastal Waray settlements along the San Bernardino Strait; fishing and
-      inter-island trade sustain early communities.
+      Austronesian settlers establish communities along the San Bernardino Strait,
+      sustaining themselves through fishing and inter-island trade. The area is
+      known as Minapa-a.
 
-  - year: December 1, 1863
+  - year: 1863
     event: >
-      Allen formally established as a municipality under Spanish colonial
-      administration.
+      The Spanish formally establish a town on these shores, naming it La Granja.
+      It marks the beginning of organized colonial administration in the area.
 
-  - year: Early 1900s
+  - year: 1903
     event: >
-      American period brings new civil governance structure; infrastructure
-      improvements begin across the municipality.
+      American colonial rule renames the town Allen, in honor of General Henry T.
+      Allen, military governor of the Visayas. Civil governance structures are
+      reorganized under the new administration.
 
   - year: 1942–1945
     event: >
-      World War II affects the municipality; post-war reconstruction shapes
-      the modern town center.
+      During the Japanese occupation, the town is briefly renamed Tanaman.
+      Post-war reconstruction gradually restores and reshapes the town center.
 
   - year: 1950s–1970s
     event: >
-      Ferry route between Allen and Matnog formalizes, establishing Allen's
-      role as a regional gateway between Luzon and the Visayas.
+      The ferry route between Allen and Matnog formalizes, cementing Allen's role
+      as the primary gateway between Luzon and the Visayas.
 
   - year: Present
     event: >

--- a/src/data/about_bettergov.yaml
+++ b/src/data/about_bettergov.yaml
@@ -6,90 +6,30 @@ tagline: A Better Philippine Government Website
 url: https://bettergov.ph
 
 description: >
-  BetterGov is a community-led volunteer initiative building a better and more usable
-  Philippine national government website. It exists to break down the barriers that
-  outdated, broken, and inaccessible government portals have created for everyday Filipinos.
+  BetterGov is a volunteer project by Filipinos, for Filipinos — built on the belief
+  that government information should be easy to find, easy to understand, and available
+  to everyone.
 
 mission: >
-  BetterGov's mission is simple: provide a "better" and "usable" website for the
-  Philippines. The project is volunteer-driven and open to anyone who wants to help
-  make government information easier to find, understand, and act on — regardless of
-  technical background.
+  BetterGov exists to make government information more accessible and more human.
+  The project is open to anyone who wants to help — developers, writers, designers,
+  and everyday citizens who believe public services should work for the public.
 
 why: >
-  The current state of Philippine government websites, particularly the main portal
-  www.gov.ph, presents serious challenges for citizens. The site is outdated and
-  unmaintained, full of broken links, and plagued by inconsistent design and poor
-  accessibility. Similar problems exist across most government agency websites. These
-  aren't just inconveniences — they are barriers that prevent Filipinos from accessing
-  essential services and information they are entitled to.
-
-stats:
-  - label: License
-    value: CC0
-    sublabel: Public domain dedication
-    icon: Globe
-
-  - label: Status
-    value: Active
-    sublabel: Actively maintained
-    icon: Activity
-
-  - label: Docs
-    value: docs.bettergov.ph
-    sublabel: Project documentation
-    icon: BookOpen
-
-  - label: Contact
-    value: volunteers@bettergov.ph
-    sublabel: Get involved
-    icon: Mail
+  Good governance starts with good communication. BetterGov was created to bridge
+  the gap between government services and the people who need them — making it easier
+  for every Filipino to understand their rights, access public services, and stay
+  informed about what their government is doing.
 
 benefits:
   - audience: For Citizens
     icon: Users
     description: >
-      BetterGov makes government services easier to find and understand. With intuitive
-      navigation, accessible design, and accurate information, Filipinos can get what
-      they need without wading through broken links or confusing layouts.
+      Clear, accessible, and up-to-date government information — so any Filipino can
+      find what they need quickly, without confusion or dead ends.
 
   - audience: For Local Governments
     icon: Landmark
     description: >
-      BetterGov demonstrates what modern, citizen-friendly government digital services
-      can look like — and provides a replicable model for LGUs looking to improve their
-      own online presence.
-
-timeline:
-  - year: The Problem
-    event: >
-      www.gov.ph and most Philippine government agency websites fall behind — outdated
-      content, broken links, inaccessible design, and poor user experience become
-      the norm.
-
-  - year: The Idea
-    event: >
-      A group of volunteers decides that waiting for a top-down fix isn't enough.
-      BetterGov is conceived as a community-led alternative — built in the open,
-      for everyone.
-
-  - year: Early Development
-    event: >
-      The project takes shape: a modern, responsive design is drafted, a
-      contributing guide and code of conduct are established, and the first
-      volunteers join the effort.
-
-  - year: Today
-    event: >
-      BetterGov continues to grow, welcoming developers, designers, writers,
-      translators, accessibility experts, and anyone who believes Filipinos
-      deserve better from their government's digital services.
-
-volunteer_roles:
-  - Frontend and backend developers
-  - UX/UI designers
-  - Content writers and editors
-  - Translators (Filipino and other local languages)
-  - Accessibility experts
-  - Project managers
-  - QA testers
+      A modern, open-source model that any LGU can learn from or build on to improve
+      their own digital presence and better serve their constituents.

--- a/src/data/about_bettergov.yaml
+++ b/src/data/about_bettergov.yaml
@@ -1,0 +1,95 @@
+# BetterGov Initiative Data
+# Non-technical contributors can edit this file to update content on the About BetterGov page.
+
+name: BetterGov
+tagline: A Better Philippine Government Website
+url: https://bettergov.ph
+
+description: >
+  BetterGov is a community-led volunteer initiative building a better and more usable
+  Philippine national government website. It exists to break down the barriers that
+  outdated, broken, and inaccessible government portals have created for everyday Filipinos.
+
+mission: >
+  BetterGov's mission is simple: provide a "better" and "usable" website for the
+  Philippines. The project is volunteer-driven and open to anyone who wants to help
+  make government information easier to find, understand, and act on — regardless of
+  technical background.
+
+why: >
+  The current state of Philippine government websites, particularly the main portal
+  www.gov.ph, presents serious challenges for citizens. The site is outdated and
+  unmaintained, full of broken links, and plagued by inconsistent design and poor
+  accessibility. Similar problems exist across most government agency websites. These
+  aren't just inconveniences — they are barriers that prevent Filipinos from accessing
+  essential services and information they are entitled to.
+
+stats:
+  - label: License
+    value: CC0
+    sublabel: Public domain dedication
+    icon: Globe
+
+  - label: Status
+    value: Active
+    sublabel: Actively maintained
+    icon: Activity
+
+  - label: Docs
+    value: docs.bettergov.ph
+    sublabel: Project documentation
+    icon: BookOpen
+
+  - label: Contact
+    value: volunteers@bettergov.ph
+    sublabel: Get involved
+    icon: Mail
+
+benefits:
+  - audience: For Citizens
+    icon: Users
+    description: >
+      BetterGov makes government services easier to find and understand. With intuitive
+      navigation, accessible design, and accurate information, Filipinos can get what
+      they need without wading through broken links or confusing layouts.
+
+  - audience: For Local Governments
+    icon: Landmark
+    description: >
+      BetterGov demonstrates what modern, citizen-friendly government digital services
+      can look like — and provides a replicable model for LGUs looking to improve their
+      own online presence.
+
+timeline:
+  - year: The Problem
+    event: >
+      www.gov.ph and most Philippine government agency websites fall behind — outdated
+      content, broken links, inaccessible design, and poor user experience become
+      the norm.
+
+  - year: The Idea
+    event: >
+      A group of volunteers decides that waiting for a top-down fix isn't enough.
+      BetterGov is conceived as a community-led alternative — built in the open,
+      for everyone.
+
+  - year: Early Development
+    event: >
+      The project takes shape: a modern, responsive design is drafted, a
+      contributing guide and code of conduct are established, and the first
+      volunteers join the effort.
+
+  - year: Today
+    event: >
+      BetterGov continues to grow, welcoming developers, designers, writers,
+      translators, accessibility experts, and anyone who believes Filipinos
+      deserve better from their government's digital services.
+
+volunteer_roles:
+  - Frontend and backend developers
+  - UX/UI designers
+  - Content writers and editors
+  - Translators (Filipino and other local languages)
+  - Accessibility experts
+  - Project managers
+  - QA testers

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -32,6 +32,10 @@ export const mainNavigation: NavigationItem[] = [
   {
     label: 'About',
     href: '/about',
+    children: [
+      { label: 'Allen', href: '/about/allen' },
+      { label: 'BetterGov', href: '/about/bettergov' },
+    ],
   },
 ];
 

--- a/src/pages/Government.tsx
+++ b/src/pages/Government.tsx
@@ -80,12 +80,12 @@ const Government: React.FC = () => {
       />
       <Section className="p-3 mb-12">
         <Breadcrumbs className="mb-8" />
-        <Icon className="h-8 w-8 mb-4 text-primary-600 rounded-md" />
+        <Icon className="w-8 h-8 mb-4 rounded-md text-primary-600" />
         <Heading>{categoryData.category || category}</Heading>
-        <Text className="text-gray-600 mb-6">{categoryData.description}</Text>
+        <Text className="mb-6 text-gray-600">{categoryData.description}</Text>
 
         {loading ? (
-          <div className="flex justify-center items-center p-8">
+          <div className="flex items-center justify-center p-8">
             <Text>Loading services...</Text>
           </div>
         ) : (
@@ -94,7 +94,7 @@ const Government: React.FC = () => {
               <Heading level={3}>{categoryIndex.title}</Heading>
             )}
             {categoryIndex.description && (
-              <Text className="text-gray-600 mb-4">
+              <Text className="mb-4 text-gray-600">
                 {categoryIndex.description}
               </Text>
             )}
@@ -118,7 +118,7 @@ const Government: React.FC = () => {
                             {subcategory.description}
                           </p>
                         )}
-                        <span className="inline-block px-2 py-1 mt-2 text-xs font-medium rounded-sm bg-gray-100 text-gray-800">
+                        <span className="inline-block px-2 py-1 mt-2 text-xs font-medium text-gray-800 bg-gray-100 rounded-sm">
                           {categoryData.category || category}
                         </span>
                       </CardContent>
@@ -143,7 +143,7 @@ const Government: React.FC = () => {
                             {subcategory.description}
                           </p>
                         )}
-                        <span className="inline-block px-2 py-1 mt-2 text-xs font-medium rounded-sm bg-gray-100 text-gray-800">
+                        <span className="inline-block px-2 py-1 mt-2 text-xs font-medium text-gray-800 bg-gray-100 rounded-sm">
                           {categoryData.category || category}
                         </span>
                       </CardContent>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import Hero from '../components/sections/Hero';
 import ServicesSection from '../components/home/ServicesSection';
 import GovernmentActivitySection from '../components/home/GovernmentActivitySection';
+import AboutSection from '../components/home/AboutSection';
 import SEO from '../components/SEO';
 
 const Home: React.FC = () => {
@@ -15,6 +16,7 @@ const Home: React.FC = () => {
         <Hero />
         <ServicesSection />
         <GovernmentActivitySection />
+        <AboutSection />
       </main>
     </>
   );

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -67,19 +67,23 @@ const AboutAllen: React.FC = () => {
       <Section className="p-1 px-6 mb-12 sm:px-10 lg:px-20 xl:px-30">
         {/* Key Statistics */}
         <div className="mb-5">
-          <div className="flex flex-col gap-4 p-2 sm:flex-row sm:justify-center">
+          <div className="grid grid-cols-2 gap-4 p-2 sm:flex sm:flex-row sm:justify-center">
             {data.stats.map(stat => {
               const Icon = resolveLucideIcon(stat.icon);
               return (
                 <div
                   key={stat.label}
-                  className="flex flex-row items-center gap-4 px-6 py-4 bg-white border shadow-sm rounded-xl sm:flex-col sm:items-center sm:justify-center sm:gap-0 sm:w-44 sm:h-44 lg:w-56 lg:h-56"
+                  className="flex flex-col items-center justify-center gap-2 px-6 py-4 bg-white border shadow-sm rounded-xl sm:gap-0 sm:w-44 sm:h-44 lg:w-56 lg:h-48"
                 >
                   <div className="inline-flex items-center justify-center flex-shrink-0 w-10 h-10 rounded-lg bg-primary-50 sm:mb-4">
                     <Icon className="w-6 h-6 text-primary-600" />
                   </div>
-                  <div className="sm:text-center">
-                    <Text className="text-xl font-bold text-blue-900 max-w-none sm:text-2xl">
+                  <div className="text-center">
+                    <Text
+                      className={`font-bold text-blue-900 max-w-none ${
+                        stat.value.length > 6 ? 'text-sm' : 'text-xl'
+                      }`}
+                    >
                       {stat.value}
                     </Text>
                     <Text className="mt-0.5 text-sm font-medium text-gray-600 max-w-none">

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -64,33 +64,32 @@ const AboutAllen: React.FC = () => {
         </div>
       </div>
 
-      {/* Key Statistics */}
-      <div className="px-8 mb-12">
-        <div className="flex justify-center gap-5 p-5 lg:grid-cols-4">
-          {data.stats.map(stat => {
-            const Icon = resolveLucideIcon(stat.icon);
-            return (
-              <div
-                key={stat.label}
-                className="flex flex-col items-center justify-center bg-white border shadow-sm ext-center p w-70 h-60 rounded-xl"
-              >
-                <div className="inline-flex items-center justify-center w-10 h-10 mx-auto mb-4 rounded-lg bg-primary-50">
-                  <Icon className="w-10 h-10 text-primary-600" />
+      <Section className="p-1 mb-12 px-30">
+        {/* Key Statistics */}
+        <div className="mb-5 ">
+          <div className="flex justify-center gap-5 p-2 lg:grid-cols-4">
+            {data.stats.map(stat => {
+              const Icon = resolveLucideIcon(stat.icon);
+              return (
+                <div
+                  key={stat.label}
+                  className="flex flex-col items-center justify-center bg-white border shadow-sm ext-center p w-70 h-60 rounded-xl"
+                >
+                  <div className="inline-flex items-center justify-center w-10 h-10 mx-auto mb-4 rounded-lg bg-primary-50">
+                    <Icon className="w-10 h-10 text-primary-600" />
+                  </div>
+                  <Text className="text-2xl font-bold text-blue-900 max-w-none">
+                    {stat.value}
+                  </Text>
+                  <Text className="mt-1 text-sm font-medium text-gray-600 max-w-none">
+                    {stat.label}
+                  </Text>
                 </div>
-                <Text className="text-2xl font-bold text-blue-900 max-w-none">
-                  {stat.value}
-                </Text>
-                <Text className="mt-1 text-sm font-medium text-gray-600 max-w-none">
-                  {stat.label}
-                </Text>
-              </div>
-            );
-          })}
+              );
+            })}
+          </div>
         </div>
-      </div>
 
-      {/* Page content */}
-      <Section className="p-3 mb-12">
         {/* History */}
         <div className="mb-12">
           <Heading level={2}>History</Heading>
@@ -118,9 +117,19 @@ const AboutAllen: React.FC = () => {
         {/* Geography */}
         <div className="mb-12">
           <Heading level={2}>Geography</Heading>
-          <Text className="mt-4 text-gray-600 max-w-none">
-            {data.geography}
-          </Text>
+          <div className="flex flex-col gap-6 mt-4 lg:flex-row">
+            <Text className="text-gray-600 max-w-none lg:w-1/2">
+              {data.geography}
+            </Text>
+            <div className="h-64 overflow-hidden border shadow-sm lg:w-1/2 rounded-xl">
+              <iframe
+                title="Allen, Northern Samar Map"
+                src="https://www.openstreetmap.org/export/embed.html?bbox=124.24%2C12.47%2C124.32%2C12.54&layer=mapnik&marker=12.505%2C124.280"
+                className="w-full h-full"
+                loading="lazy"
+              />
+            </div>
+          </div>
         </div>
       </Section>
     </>

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -117,15 +117,54 @@ const AboutAllen: React.FC = () => {
         {/* Geography */}
         <div className="mb-12">
           <Heading level={2}>Geography</Heading>
-          <div className="flex flex-col gap-6 mt-4 lg:flex-row">
-            <Text className="text-gray-600 max-w-none lg:w-1/2">
-              {data.geography}
-            </Text>
-            <div className="h-64 overflow-hidden border shadow-sm lg:w-1/2 rounded-xl">
+          <div className="flex flex-col gap-6 mt-6 lg:flex-row">
+            {/* Description card */}
+            <div className="lg:w-1/2">
+              <div className="p-6 border bg-primary-50 border-primary-100 rounded-xl">
+                <div className="flex items-center gap-2 mb-3">
+                  <div className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary-600">
+                    <svg
+                      className="w-4 h-4 text-white"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                      />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                      />
+                    </svg>
+                  </div>
+                  <Text className="text-sm font-semibold text-primary-700 max-w-none">
+                    Northern Samar, Eastern Visayas
+                  </Text>
+                </div>
+                <Text className="leading-relaxed text-gray-700 max-w-none">
+                  {data.geography}
+                </Text>
+              </div>
+            </div>
+
+            {/* Map */}
+            <div className="overflow-hidden border border-gray-200 shadow-md lg:w-1/2 rounded-xl">
+              <div className="flex items-center gap-2 px-4 py-2 bg-primary-600">
+                <div className="w-2 h-2 bg-white rounded-full opacity-60" />
+                <Text className="text-xs font-medium text-white max-w-none">
+                  Allen, Northern Samar — Interactive Map
+                </Text>
+              </div>
               <iframe
                 title="Allen, Northern Samar Map"
                 src="https://www.openstreetmap.org/export/embed.html?bbox=124.24%2C12.47%2C124.32%2C12.54&layer=mapnik&marker=12.505%2C124.280"
-                className="w-full h-full"
+                className="w-full h-72"
                 loading="lazy"
               />
             </div>

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -69,20 +69,22 @@ const AboutAllen: React.FC = () => {
         {/* History */}
         <div className="mb-12">
           <Heading level={2}>History</Heading>
-          <Text className="mt-4 text-gray-600 max-w-none">{data.history}</Text>
-        </div>
+          <Text className="mt-2 mb-8 text-gray-500 max-w-none">
+            {data.history}
+          </Text>
 
-        {/* Timeline */}
-        <div className="mb-12">
-          <Heading level={2}>Timeline</Heading>
-          <div className="relative pl-6 mt-6 space-y-8 border-l-2 border-primary-200">
+          <div className="relative pl-8 space-y-6 border-l-2 border-primary-200">
             {data.timeline.map(entry => (
               <div key={entry.year} className="relative">
-                <div className="absolute -left-[1.65rem] top-1 w-3 h-3 rounded-full bg-primary-500 border-2 border-white" />
-                <Text className="mb-1 text-sm font-semibold text-primary-600 max-w-none">
-                  {entry.year}
-                </Text>
-                <Text className="text-gray-600 max-w-none">{entry.event}</Text>
+                <div className="absolute -left-[2.35rem] top-1.5 w-4 h-4 rounded-full bg-primary-500 border-4 border-white ring-2 ring-primary-300" />
+                <div className="p-4 transition-all duration-200 bg-white border border-gray-200 shadow-sm rounded-xl hover:border-primary-400 hover:shadow-md">
+                  <Text className="mb-1 text-sm font-bold text-primary-600 max-w-none">
+                    {entry.year}
+                  </Text>
+                  <Text className="text-sm text-gray-600 max-w-none">
+                    {entry.event}
+                  </Text>
+                </div>
               </div>
             ))}
           </div>
@@ -125,12 +127,6 @@ const AboutAllen: React.FC = () => {
           <Text className="mt-4 text-gray-600 max-w-none">
             {data.geography}
           </Text>
-        </div>
-
-        {/* Economy */}
-        <div className="mb-12">
-          <Heading level={2}>Economy</Heading>
-          <Text className="mt-4 text-gray-600 max-w-none">{data.economy}</Text>
         </div>
       </Section>
     </>

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -39,14 +39,14 @@ const AboutAllen: React.FC = () => {
 
         {/* Key Statistics */}
         <div className="mb-12">
-          <Heading level={2}>Key Statistics</Heading>
+          <Heading level={2}>Allen at a glance</Heading>
           <div className="grid grid-cols-2 gap-4 mt-4 sm:grid-cols-4">
             {/* TODO: Replace with real stats */}
             {[
-              { label: 'Population', value: 'TODO' },
-              { label: 'Land Area', value: 'TODO' },
-              { label: 'Barangays', value: 'TODO' },
-              { label: 'Founded', value: 'TODO' },
+              { label: 'Population', value: '26,527' },
+              { label: 'Land Area', value: '47.60 km2' },
+              { label: 'Barangays', value: '20' },
+              { label: 'Founded', value: 'December 1, 1863' },
             ].map(stat => (
               <div
                 key={stat.label}

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -1,0 +1,80 @@
+import SEO from '../../components/SEO';
+import Section from '../../components/ui/Section';
+import { Heading } from '../../components/ui/Heading';
+import { Text } from '../../components/ui/Text';
+import Breadcrumbs from '../../components/ui/Breadcrumbs';
+
+const breadcrumbs = [
+  { label: 'Home', href: '/' },
+  { label: 'About', href: '/about/allen' },
+  { label: 'Allen', href: '/about/allen' },
+];
+
+const AboutAllen: React.FC = () => {
+  return (
+    <>
+      <SEO
+        title="About Allen"
+        description="Learn about Allen, a municipality in Northern Samar, Philippines."
+        keywords="Allen, Northern Samar, municipality, history, Philippines"
+      />
+      <Section className="py-12">
+        <Breadcrumbs className="mb-8" items={breadcrumbs} />
+
+        {/* Hero / Introduction */}
+        <div className="mb-12">
+          <Heading level={1}>Allen, Northern Samar</Heading>
+          <Text className="max-w-2xl mt-4 text-gray-600">
+            TODO: Brief description of Allen municipality.
+          </Text>
+        </div>
+
+        {/* Short History */}
+        <div className="mb-12">
+          <Heading level={2}>History</Heading>
+          <Text className="mt-4 text-gray-600">
+            TODO: Short history of Allen.
+          </Text>
+        </div>
+
+        {/* Key Statistics */}
+        <div className="mb-12">
+          <Heading level={2}>Key Statistics</Heading>
+          <div className="grid grid-cols-2 gap-4 mt-4 sm:grid-cols-4">
+            {/* TODO: Replace with real stats */}
+            {[
+              { label: 'Population', value: 'TODO' },
+              { label: 'Land Area', value: 'TODO' },
+              { label: 'Barangays', value: 'TODO' },
+              { label: 'Founded', value: 'TODO' },
+            ].map(stat => (
+              <div
+                key={stat.label}
+                className="p-4 text-center border rounded-lg"
+              >
+                <Text className="text-2xl font-bold text-primary-600">
+                  {stat.value}
+                </Text>
+                <Text className="text-sm text-gray-500">{stat.label}</Text>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Optional: Geography */}
+        <div className="mb-12">
+          <Heading level={2}>Geography</Heading>
+          <Text className="mt-4 text-gray-600">TODO: Geography section.</Text>
+        </div>
+
+        {/* Optional: Economy */}
+        <div className="mb-12">
+          <Heading level={2}>Economy</Heading>
+          <Text className="mt-4 text-gray-600">TODO: Economy section.</Text>
+        </div>
+      </Section>
+    </>
+  );
+};
+
+export default AboutAllen;

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -58,7 +58,7 @@ const AboutAllen: React.FC = () => {
           <Heading level={1} className="text-white">
             {data.name}, {data.province}
           </Heading>
-          <Text className="mt-4 text-primary-100 max-w-none sm:px-8 lg:px-16">
+          <Text className="mt-4 text-primary-100 max-w-none sm:px-8 lg:px-40">
             {data.description}
           </Text>
         </div>

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -50,7 +50,7 @@ const AboutAllen: React.FC = () => {
 
       {/* Blue hero banner */}
       <div className="py-12 text-white bg-linear-to-r from-primary-600 to-primary-700">
-        <div className="container px-40 mx-auto text-center">
+        <div className="container px-6 mx-auto text-center sm:px-12 lg:px-20">
           <Breadcrumbs
             className="justify-center mb-6 text-white"
             items={breadcrumbs}
@@ -58,32 +58,35 @@ const AboutAllen: React.FC = () => {
           <Heading level={1} className="text-white">
             {data.name}, {data.province}
           </Heading>
-          <Text className="px-32 mt-4 text-primary-100 max-w-none">
+          <Text className="mt-4 text-primary-100 max-w-none sm:px-8 lg:px-16">
             {data.description}
           </Text>
         </div>
       </div>
 
-      <Section className="p-1 mb-12 px-30">
+      <Section className="p-1 px-6 mb-12 sm:px-10 lg:px-20 xl:px-30">
         {/* Key Statistics */}
         <div className="mb-5 ">
-          <div className="flex justify-center gap-5 p-2 lg:grid-cols-4">
+          {/* Mobile: 1x4 column. Desktop: 1x4 row of squares */}
+          <div className="flex flex-col gap-4 p-2 sm:flex-row sm:justify-center">
             {data.stats.map(stat => {
               const Icon = resolveLucideIcon(stat.icon);
               return (
                 <div
                   key={stat.label}
-                  className="flex flex-col items-center justify-center bg-white border shadow-sm ext-center p w-70 h-60 rounded-xl"
+                  className="flex flex-row items-center gap-4 px-6 py-4 bg-white border shadow-sm rounded-xl sm:flex-col sm:items-center sm:justify-center sm:gap-0 sm:w-44 sm:h-44 lg:w-56 lg:h-56"
                 >
-                  <div className="inline-flex items-center justify-center w-10 h-10 mx-auto mb-4 rounded-lg bg-primary-50">
-                    <Icon className="w-10 h-10 text-primary-600" />
+                  <div className="inline-flex items-center justify-center flex-shrink-0 w-10 h-10 rounded-lg bg-primary-50 sm:mb-4">
+                    <Icon className="w-6 h-6 text-primary-600" />
                   </div>
-                  <Text className="text-2xl font-bold text-blue-900 max-w-none">
-                    {stat.value}
-                  </Text>
-                  <Text className="mt-1 text-sm font-medium text-gray-600 max-w-none">
-                    {stat.label}
-                  </Text>
+                  <div className="sm:text-center">
+                    <Text className="text-xl font-bold text-blue-900 max-w-none sm:text-2xl">
+                      {stat.value}
+                    </Text>
+                    <Text className="mt-0.5 text-sm font-medium text-gray-600 max-w-none">
+                      {stat.label}
+                    </Text>
+                  </div>
                 </div>
               );
             })}

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -3,150 +3,134 @@ import Section from '../../components/ui/Section';
 import { Heading } from '../../components/ui/Heading';
 import { Text } from '../../components/ui/Text';
 import Breadcrumbs from '../../components/ui/Breadcrumbs';
-import { Users, MapPin, Map, Award } from 'lucide-react';
+import { resolveLucideIcon } from '../../lib/utils';
+import yaml from 'js-yaml';
+import allenYaml from '../../data/about_allen.yaml?raw';
+
+interface Stat {
+  label: string;
+  value: string;
+  sublabel?: string;
+  asOf?: string;
+  icon?: string;
+}
+
+interface TimelineEntry {
+  year: string;
+  event: string;
+}
+
+interface AllenData {
+  name: string;
+  province: string;
+  description: string;
+  history: string;
+  geography: string;
+  economy: string;
+  stats: Stat[];
+  timeline: TimelineEntry[];
+}
+
+const data = yaml.load(allenYaml) as AllenData;
 
 const breadcrumbs = [
   { label: 'Home', href: '/' },
-  { label: 'About', href: '/about/allen' },
+  { label: 'About', href: '/about' },
   { label: 'Allen', href: '/about/allen' },
-];
-
-const stats = [
-  {
-    icon: Users,
-    value: '26,527',
-    label: 'Population',
-    sublabel: 'Estimated residents',
-    asOf: 'As of 2020 census',
-  },
-  {
-    icon: MapPin,
-    value: '20',
-    label: 'Barangays',
-    sublabel: 'Administrative divisions',
-    asOf: 'As of 2025',
-  },
-  {
-    icon: Map,
-    value: '47.60 km²',
-    label: 'Land Area',
-    sublabel: 'Total municipal coverage',
-    asOf: 'As of 2025',
-  },
-  {
-    icon: Award,
-    value: 'December 1, 1863',
-    label: 'Founded',
-    sublabel: 'Date of establishment',
-    asOf: '',
-  },
 ];
 
 const AboutAllen: React.FC = () => {
   return (
     <>
       <SEO
-        title="About Allen"
-        description="Learn about Allen, a municipality in Northern Samar, Philippines."
-        keywords="Allen, Northern Samar, municipality, history, Philippines"
+        title={`About ${data.name}`}
+        description={data.description}
+        keywords={`${data.name}, ${data.province}, municipality, history, Philippines`}
       />
-      <Section className="py-12">
-        <Breadcrumbs className="mb-8" items={breadcrumbs} />
 
-        {/* Hero / Introduction */}
-        <div className="mb-12">
-          <Heading level={1}>Allen, Northern Samar</Heading>
-          <Text className="max-w-2xl mt-4 text-gray-600">
-            Allen is a coastal municipality in Northern Samar and the southern
-            gateway between Luzon and the Visayas. Sitting along the San
-            Bernardino Strait, it is where the ferry from Matnog, Sorsogon
-            arrives — making it one of the most-travelled entry points into the
-            Eastern Visayas region. Behind the busy port is a close-knit
-            community of fisherfolk, farmers, and families who have called this
-            stretch of coastline home for generations.
+      {/* Blue hero banner */}
+      <div className="py-12 text-white bg-linear-to-r from-primary-600 to-primary-700">
+        <div className="container px-40 mx-auto text-center">
+          <Breadcrumbs
+            className="justify-center mb-6 text-white"
+            items={breadcrumbs}
+          />
+          <Heading level={1} className="text-white">
+            {data.name}, {data.province}
+          </Heading>
+          <Text className="px-32 mt-4 text-primary-100 max-w-none">
+            {data.description}
           </Text>
         </div>
+      </div>
 
-        {/* Short History */}
+      {/* Page content */}
+      <Section className="p-3 mb-12">
+        {/* History */}
         <div className="mb-12">
           <Heading level={2}>History</Heading>
-          <Text className="mt-4 text-gray-600">
-            Allen was formally established on December 1, 1863, during the
-            Spanish colonial period, though the area had long been settled by
-            coastal communities who depended on fishing and trade along the
-            strait. Over the centuries, Allen grew from a quiet seaside town
-            into a significant transit point — shaped by colonial
-            administration, war, and the steady movement of people between
-            islands.
-          </Text>
+          <Text className="mt-4 text-gray-600 max-w-none">{data.history}</Text>
+        </div>
+
+        {/* Timeline */}
+        <div className="mb-12">
+          <Heading level={2}>Timeline</Heading>
+          <div className="relative pl-6 mt-6 space-y-8 border-l-2 border-primary-200">
+            {data.timeline.map(entry => (
+              <div key={entry.year} className="relative">
+                <div className="absolute -left-[1.65rem] top-1 w-3 h-3 rounded-full bg-primary-500 border-2 border-white" />
+                <Text className="mb-1 text-sm font-semibold text-primary-600 max-w-none">
+                  {entry.year}
+                </Text>
+                <Text className="text-gray-600 max-w-none">{entry.event}</Text>
+              </div>
+            ))}
+          </div>
         </div>
 
         {/* Key Statistics */}
-        <div className="mb-12 text-center">
-          <Heading level={2}>Allen at a Glance</Heading>
-          <Text className="mt-2 text-gray-500">
-            Key statistics about our municipality
-          </Text>
-
-          <div className="grid grid-cols-1 gap-4 mt-8 sm:grid-cols-2 lg:grid-cols-4">
-            {stats.map(stat => {
-              const Icon = stat.icon;
+        <div className="px-8 mb-12">
+          <div className="mb-8 text-center">
+            <Heading level={2}>Allen at a Glance</Heading>
+            <Text className="mt-2 text-gray-500 max-w-none">
+              Key statistics about our municipality
+            </Text>
+          </div>
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+            {data.stats.map(stat => {
+              const Icon = resolveLucideIcon(stat.icon);
               return (
                 <div
                   key={stat.label}
-                  className="p-6 text-left bg-white border shadow-sm rounded-xl"
+                  className="p-6 text-center bg-white border shadow-sm rounded-xl"
                 >
-                  <div className="inline-flex items-center justify-center w-10 h-10 mb-4 rounded-lg bg-primary-50">
+                  <div className="inline-flex items-center justify-center w-10 h-10 mx-auto mb-4 rounded-lg bg-primary-50">
                     <Icon className="w-5 h-5 text-primary-600" />
                   </div>
-                  <Text className="text-2xl font-bold text-gray-900">
+                  <Text className="text-2xl font-bold text-gray-900 max-w-none">
                     {stat.value}
                   </Text>
-                  <Text className="mt-1 text-sm font-medium text-gray-700">
+                  <Text className="mt-1 text-sm font-medium text-gray-700 max-w-none">
                     {stat.label}
                   </Text>
-                  <Text className="text-xs text-gray-400">{stat.sublabel}</Text>
-                  {stat.asOf && (
-                    <Text className="mt-1 text-xs text-gray-400">
-                      {stat.asOf}
-                    </Text>
-                  )}
                 </div>
               );
             })}
           </div>
         </div>
 
-        {/* Optional: Geography */}
+        {/* Geography */}
         <div className="mb-12">
           <Heading level={2}>Geography</Heading>
-          <Text className="mt-4 text-gray-600">
-            Allen occupies a narrow coastal strip along the northern tip of
-            Samar, facing the San Bernardino Strait to the north. The
-            municipality covers 47.60 km² of land, with terrain that transitions
-            from a flat coastal shoreline into rolling hills inland. The strait
-            separates Samar from the Bicol Peninsula of Luzon, making Allen's
-            position geographically significant — it sits at the natural
-            crossing point between two major island groups. The town proper hugs
-            the coast, while its 20 barangays spread inland and along adjacent
-            shorelines. .
+          <Text className="mt-4 text-gray-600 max-w-none">
+            {data.geography}
           </Text>
         </div>
 
-        {/* Optional: Economy */}
+        {/* Economy */}
         <div className="mb-12">
           <Heading level={2}>Economy</Heading>
-          <Text className="mt-4 text-gray-600">
-            Allen's economy is anchored by fishing and the movement of goods and
-            people through its port. The San Bernardino Strait provides rich
-            fishing grounds, and many residents make their living from the sea —
-            supplying local markets and nearby towns with fresh catch. The RoRo
-            (Roll-on/Roll-off) ferry terminal connecting Allen to Matnog,
-            Sorsogon drives consistent commercial activity: transport services,
-            small trading, eateries, and informal vendors all cluster around the
-            port area. Agriculture — primarily coconut farming and rice —
-            supplements livelihoods further inland.
-          </Text>
+          <Text className="mt-4 text-gray-600 max-w-none">{data.economy}</Text>
         </div>
       </Section>
     </>

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -3,11 +3,43 @@ import Section from '../../components/ui/Section';
 import { Heading } from '../../components/ui/Heading';
 import { Text } from '../../components/ui/Text';
 import Breadcrumbs from '../../components/ui/Breadcrumbs';
+import { Users, MapPin, Map, Award } from 'lucide-react';
 
 const breadcrumbs = [
   { label: 'Home', href: '/' },
   { label: 'About', href: '/about/allen' },
   { label: 'Allen', href: '/about/allen' },
+];
+
+const stats = [
+  {
+    icon: Users,
+    value: '26,527',
+    label: 'Population',
+    sublabel: 'Estimated residents',
+    asOf: 'As of 2020 census',
+  },
+  {
+    icon: MapPin,
+    value: '20',
+    label: 'Barangays',
+    sublabel: 'Administrative divisions',
+    asOf: 'As of 2025',
+  },
+  {
+    icon: Map,
+    value: '47.60 km²',
+    label: 'Land Area',
+    sublabel: 'Total municipal coverage',
+    asOf: 'As of 2025',
+  },
+  {
+    icon: Award,
+    value: 'December 1, 1863',
+    label: 'Founded',
+    sublabel: 'Date of establishment',
+    asOf: '',
+  },
 ];
 
 const AboutAllen: React.FC = () => {
@@ -25,7 +57,13 @@ const AboutAllen: React.FC = () => {
         <div className="mb-12">
           <Heading level={1}>Allen, Northern Samar</Heading>
           <Text className="max-w-2xl mt-4 text-gray-600">
-            TODO: Brief description of Allen municipality.
+            Allen is a coastal municipality in Northern Samar and the southern
+            gateway between Luzon and the Visayas. Sitting along the San
+            Bernardino Strait, it is where the ferry from Matnog, Sorsogon
+            arrives — making it one of the most-travelled entry points into the
+            Eastern Visayas region. Behind the busy port is a close-knit
+            community of fisherfolk, farmers, and families who have called this
+            stretch of coastline home for generations.
           </Text>
         </div>
 
@@ -33,44 +71,82 @@ const AboutAllen: React.FC = () => {
         <div className="mb-12">
           <Heading level={2}>History</Heading>
           <Text className="mt-4 text-gray-600">
-            TODO: Short history of Allen.
+            Allen was formally established on December 1, 1863, during the
+            Spanish colonial period, though the area had long been settled by
+            coastal communities who depended on fishing and trade along the
+            strait. Over the centuries, Allen grew from a quiet seaside town
+            into a significant transit point — shaped by colonial
+            administration, war, and the steady movement of people between
+            islands.
           </Text>
         </div>
 
         {/* Key Statistics */}
-        <div className="mb-12">
-          <Heading level={2}>Allen at a glance</Heading>
-          <div className="grid grid-cols-2 gap-4 mt-4 sm:grid-cols-4">
-            {/* TODO: Replace with real stats */}
-            {[
-              { label: 'Population', value: '26,527' },
-              { label: 'Land Area', value: '47.60 km2' },
-              { label: 'Barangays', value: '20' },
-              { label: 'Founded', value: 'December 1, 1863' },
-            ].map(stat => (
-              <div
-                key={stat.label}
-                className="p-4 text-center border rounded-lg"
-              >
-                <Text className="text-2xl font-bold text-primary-600">
-                  {stat.value}
-                </Text>
-                <Text className="text-sm text-gray-500">{stat.label}</Text>
-              </div>
-            ))}
+        <div className="mb-12 text-center">
+          <Heading level={2}>Allen at a Glance</Heading>
+          <Text className="mt-2 text-gray-500">
+            Key statistics about our municipality
+          </Text>
+
+          <div className="grid grid-cols-1 gap-4 mt-8 sm:grid-cols-2 lg:grid-cols-4">
+            {stats.map(stat => {
+              const Icon = stat.icon;
+              return (
+                <div
+                  key={stat.label}
+                  className="p-6 text-left bg-white border shadow-sm rounded-xl"
+                >
+                  <div className="inline-flex items-center justify-center w-10 h-10 mb-4 rounded-lg bg-primary-50">
+                    <Icon className="w-5 h-5 text-primary-600" />
+                  </div>
+                  <Text className="text-2xl font-bold text-gray-900">
+                    {stat.value}
+                  </Text>
+                  <Text className="mt-1 text-sm font-medium text-gray-700">
+                    {stat.label}
+                  </Text>
+                  <Text className="text-xs text-gray-400">{stat.sublabel}</Text>
+                  {stat.asOf && (
+                    <Text className="mt-1 text-xs text-gray-400">
+                      {stat.asOf}
+                    </Text>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
 
         {/* Optional: Geography */}
         <div className="mb-12">
           <Heading level={2}>Geography</Heading>
-          <Text className="mt-4 text-gray-600">TODO: Geography section.</Text>
+          <Text className="mt-4 text-gray-600">
+            Allen occupies a narrow coastal strip along the northern tip of
+            Samar, facing the San Bernardino Strait to the north. The
+            municipality covers 47.60 km² of land, with terrain that transitions
+            from a flat coastal shoreline into rolling hills inland. The strait
+            separates Samar from the Bicol Peninsula of Luzon, making Allen's
+            position geographically significant — it sits at the natural
+            crossing point between two major island groups. The town proper hugs
+            the coast, while its 20 barangays spread inland and along adjacent
+            shorelines. .
+          </Text>
         </div>
 
         {/* Optional: Economy */}
         <div className="mb-12">
           <Heading level={2}>Economy</Heading>
-          <Text className="mt-4 text-gray-600">TODO: Economy section.</Text>
+          <Text className="mt-4 text-gray-600">
+            Allen's economy is anchored by fishing and the movement of goods and
+            people through its port. The San Bernardino Strait provides rich
+            fishing grounds, and many residents make their living from the sea —
+            supplying local markets and nearby towns with fresh catch. The RoRo
+            (Roll-on/Roll-off) ferry terminal connecting Allen to Matnog,
+            Sorsogon drives consistent commercial activity: transport services,
+            small trading, eateries, and informal vendors all cluster around the
+            port area. Agriculture — primarily coconut farming and rice —
+            supplements livelihoods further inland.
+          </Text>
         </div>
       </Section>
     </>

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -64,6 +64,31 @@ const AboutAllen: React.FC = () => {
         </div>
       </div>
 
+      {/* Key Statistics */}
+      <div className="px-8 mb-12">
+        <div className="flex justify-center gap-5 p-5 lg:grid-cols-4">
+          {data.stats.map(stat => {
+            const Icon = resolveLucideIcon(stat.icon);
+            return (
+              <div
+                key={stat.label}
+                className="flex flex-col items-center justify-center bg-white border shadow-sm ext-center p w-70 h-60 rounded-xl"
+              >
+                <div className="inline-flex items-center justify-center w-10 h-10 mx-auto mb-4 rounded-lg bg-primary-50">
+                  <Icon className="w-10 h-10 text-primary-600" />
+                </div>
+                <Text className="text-2xl font-bold text-blue-900 max-w-none">
+                  {stat.value}
+                </Text>
+                <Text className="mt-1 text-sm font-medium text-gray-600 max-w-none">
+                  {stat.label}
+                </Text>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
       {/* Page content */}
       <Section className="p-3 mb-12">
         {/* History */}
@@ -87,37 +112,6 @@ const AboutAllen: React.FC = () => {
                 </div>
               </div>
             ))}
-          </div>
-        </div>
-
-        {/* Key Statistics */}
-        <div className="px-8 mb-12">
-          <div className="mb-8 text-center">
-            <Heading level={2}>Allen at a Glance</Heading>
-            <Text className="mt-2 text-gray-500 max-w-none">
-              Key statistics about our municipality
-            </Text>
-          </div>
-          <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-            {data.stats.map(stat => {
-              const Icon = resolveLucideIcon(stat.icon);
-              return (
-                <div
-                  key={stat.label}
-                  className="p-6 text-center bg-white border shadow-sm rounded-xl"
-                >
-                  <div className="inline-flex items-center justify-center w-10 h-10 mx-auto mb-4 rounded-lg bg-primary-50">
-                    <Icon className="w-5 h-5 text-primary-600" />
-                  </div>
-                  <Text className="text-2xl font-bold text-gray-900 max-w-none">
-                    {stat.value}
-                  </Text>
-                  <Text className="mt-1 text-sm font-medium text-gray-700 max-w-none">
-                    {stat.label}
-                  </Text>
-                </div>
-              );
-            })}
           </div>
         </div>
 

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -66,8 +66,7 @@ const AboutAllen: React.FC = () => {
 
       <Section className="p-1 px-6 mb-12 sm:px-10 lg:px-20 xl:px-30">
         {/* Key Statistics */}
-        <div className="mb-5 ">
-          {/* Mobile: 1x4 column. Desktop: 1x4 row of squares */}
+        <div className="mb-5">
           <div className="flex flex-col gap-4 p-2 sm:flex-row sm:justify-center">
             {data.stats.map(stat => {
               const Icon = resolveLucideIcon(stat.icon);
@@ -120,56 +119,56 @@ const AboutAllen: React.FC = () => {
         {/* Geography */}
         <div className="mb-12">
           <Heading level={2}>Geography</Heading>
-          <div className="flex flex-col gap-6 mt-6 lg:flex-row">
-            {/* Description card */}
-            <div className="lg:w-1/2">
-              <div className="p-6 border bg-primary-50 border-primary-100 rounded-xl">
-                <div className="flex items-center gap-2 mb-3">
-                  <div className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary-600">
-                    <svg
-                      className="w-4 h-4 text-white"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                      />
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                      />
-                    </svg>
+
+          <div className="mt-6">
+            {/* Unified Container */}
+            <div className="overflow-hidden border bg-primary-50 border-primary-100 rounded-xl">
+              <div className="flex flex-col lg:flex-row">
+                {/* Description Side */}
+                <div className="p-8 lg:w-1/2">
+                  <div className="flex items-center gap-2 mb-4">
+                    <div className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary-600">
+                      <svg
+                        className="w-4 h-4 text-white"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                        />
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                        />
+                      </svg>
+                    </div>
+                    <Text className="text-sm font-bold tracking-wide uppercase text-primary-700">
+                      Northern Samar, Eastern Visayas
+                    </Text>
                   </div>
-                  <Text className="text-sm font-semibold text-primary-700 max-w-none">
-                    Northern Samar, Eastern Visayas
+                  <Text className="leading-relaxed text-gray-700 max-w-none">
+                    {data.geography}
                   </Text>
                 </div>
-                <Text className="leading-relaxed text-gray-700 max-w-none">
-                  {data.geography}
-                </Text>
-              </div>
-            </div>
 
-            {/* Map */}
-            <div className="overflow-hidden border border-gray-200 shadow-md lg:w-1/2 rounded-xl">
-              <div className="flex items-center gap-2 px-4 py-2 bg-primary-600">
-                <div className="w-2 h-2 bg-white rounded-full opacity-60" />
-                <Text className="text-xs font-medium text-white max-w-none">
-                  Allen, Northern Samar — Interactive Map
-                </Text>
+                {/* Integrated Map Side */}
+                <div className="relative flex items-stretch p-4 lg:p-6 lg:w-1/2">
+                  <div className="relative w-full overflow-hidden bg-white border shadow-inner rounded-xl border-primary-200/50">
+                    <iframe
+                      title="Allen, Northern Samar Map"
+                      src="https://maps.google.com/maps?q=12.5,124.282&z=14&output=embed"
+                      className="w-full h-80 lg:h-full min-h-[300px]"
+                      loading="lazy"
+                    />
+                  </div>
+                </div>
               </div>
-              <iframe
-                title="Allen, Northern Samar Map"
-                src="https://www.openstreetmap.org/export/embed.html?bbox=124.24%2C12.47%2C124.32%2C12.54&layer=mapnik&marker=12.505%2C124.280"
-                className="w-full h-72"
-                loading="lazy"
-              />
             </div>
           </div>
         </div>

--- a/src/pages/about/BetterGov.tsx
+++ b/src/pages/about/BetterGov.tsx
@@ -3,10 +3,30 @@ import Section from '../../components/ui/Section';
 import { Heading } from '../../components/ui/Heading';
 import { Text } from '../../components/ui/Text';
 import Breadcrumbs from '../../components/ui/Breadcrumbs';
+import { resolveLucideIcon } from '../../lib/utils';
+import yaml from 'js-yaml';
+import betterGovYaml from '../../data/about_bettergov.yaml?raw';
+
+interface Benefit {
+  audience: string;
+  icon?: string;
+  description: string;
+}
+
+interface BetterGovData {
+  name: string;
+  tagline: string;
+  description: string;
+  mission: string;
+  why: string;
+  benefits: Benefit[];
+}
+
+const data = yaml.load(betterGovYaml) as BetterGovData;
 
 const breadcrumbs = [
   { label: 'Home', href: '/' },
-  { label: 'About', href: '/about/bettergov' },
+  { label: 'About', href: '/about' },
   { label: 'BetterGov', href: '/about/bettergov' },
 ];
 
@@ -14,53 +34,140 @@ const AboutBetterGov: React.FC = () => {
   return (
     <>
       <SEO
-        title="About BetterGov"
-        description="Learn about the BetterGov initiative and the BetterLGU project."
+        title={`About ${data.name}`}
+        description={data.description}
         keywords="BetterGov, BetterLGU, local government, civic technology, Philippines"
       />
-      <Section className="py-12">
-        <Breadcrumbs className="mb-8" items={breadcrumbs} />
 
-        {/* Hero / Introduction */}
+      {/* Blue hero banner */}
+      <div className="py-12 text-white bg-linear-to-r from-primary-600 to-primary-700">
+        <div className="container px-6 mx-auto text-center sm:px-12 lg:px-20">
+          <Breadcrumbs
+            className="justify-center mb-6 text-white"
+            items={breadcrumbs}
+          />
+          <Heading level={1} className="text-white">
+            {data.name}
+          </Heading>
+          <Text className="mt-4 text-primary-100 max-w-none sm:px-8 lg:px-16">
+            {data.tagline}
+          </Text>
+        </div>
+      </div>
+
+      <Section className="p-1 px-6 mb-12 sm:px-10 lg:px-20 xl:px-30">
+        {/* What is BetterGov */}
         <div className="mb-12">
-          <Heading level={1}>About BetterGov</Heading>
-          <Text className="max-w-2xl mt-4 text-gray-600">
-            TODO: What BetterGov is and the BetterLGU initiative.
+          <Text className="text-lg leading-relaxed text-gray-700 max-w-none">
+            {data.description}
           </Text>
         </div>
 
-        {/* Mission and Goals */}
-        <div className="mb-12">
-          <Heading level={2}>Mission and Goals</Heading>
-          <Text className="mt-4 text-gray-600">
-            TODO: Mission and goals of BetterGov.
+        <hr className="mb-12 border-gray-200" />
+
+        {/* Mission */}
+        <div className="mb-10">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="inline-block w-1 h-5 rounded-full bg-primary-500" />
+            <Text className="text-xs font-bold tracking-widest uppercase text-primary-500 max-w-none">
+              Our Mission
+            </Text>
+          </div>
+          <Heading level={2} className="mb-3 text-gray-900">
+            What We&apos;re Here to Do
+          </Heading>
+          <Text className="leading-relaxed text-gray-600 max-w-none">
+            {data.mission}
           </Text>
         </div>
 
-        {/* Why It Was Created */}
+        {/* Why It Exists */}
         <div className="mb-12">
-          <Heading level={2}>Why It Was Created</Heading>
-          <Text className="mt-4 text-gray-600">
-            TODO: Why BetterGov was created.
+          <div className="flex items-center gap-2 mb-2">
+            <span className="inline-block w-1 h-5 rounded-full bg-primary-500" />
+            <Text className="text-xs font-bold tracking-widest uppercase text-primary-500 max-w-none">
+              Why It Exists
+            </Text>
+          </div>
+          <Heading level={2} className="mb-3 text-gray-900">
+            The Problem We&apos;re Solving
+          </Heading>
+          <Text className="leading-relaxed text-gray-600 max-w-none">
+            {data.why}
           </Text>
         </div>
 
-        {/* How LGUs and Citizens Benefit */}
+        <hr className="mb-12 border-gray-200" />
+
+        {/* Who It's For */}
         <div className="mb-12">
-          <Heading level={2}>How It Helps</Heading>
-          <div className="grid grid-cols-1 gap-6 mt-4 sm:grid-cols-2">
-            <div className="p-6 border rounded-lg">
-              <Heading level={3}>For Local Governments</Heading>
-              <Text className="mt-2 text-gray-600">
-                TODO: How LGUs benefit.
-              </Text>
-            </div>
-            <div className="p-6 border rounded-lg">
-              <Heading level={3}>For Citizens</Heading>
-              <Text className="mt-2 text-gray-600">
-                TODO: How citizens benefit.
-              </Text>
-            </div>
+          <div className="flex items-center gap-2 mb-2">
+            <span className="inline-block w-1 h-5 rounded-full bg-primary-500" />
+            <Text className="text-xs font-bold tracking-widest uppercase text-primary-500 max-w-none">
+              Who It&apos;s For
+            </Text>
+          </div>
+          <Heading level={2} className="mb-6 text-gray-900">
+            Built for Every Filipino
+          </Heading>
+          <div className="flex flex-col gap-4 lg:flex-row">
+            {data.benefits.map(benefit => {
+              const Icon = resolveLucideIcon(benefit.icon);
+              return (
+                <div
+                  key={benefit.audience}
+                  className="flex flex-col gap-3 p-6 border border-primary-100 bg-primary-50 rounded-2xl lg:w-1/2"
+                >
+                  <div className="flex items-center gap-2">
+                    <div className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary-600 shrink-0">
+                      <Icon className="w-4 h-4 text-white" />
+                    </div>
+                    <Text className="font-semibold text-primary-800 max-w-none">
+                      {benefit.audience}
+                    </Text>
+                  </div>
+                  <Text className="text-sm leading-relaxed text-gray-600 max-w-none">
+                    {benefit.description}
+                  </Text>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <hr className="mb-12 border-gray-200" />
+
+        {/* Get Involved */}
+        <div className="mb-4">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="inline-block w-1 h-5 rounded-full bg-primary-500" />
+            <Text className="text-xs font-bold tracking-widest uppercase text-primary-500 max-w-none">
+              Get Involved
+            </Text>
+          </div>
+          <Heading level={2} className="mb-3 text-gray-900">
+            Help Us Build It
+          </Heading>
+          <Text className="mb-5 leading-relaxed text-gray-600 max-w-none">
+            BetterGov is open to anyone who believes Filipinos deserve better
+            from their government&apos;s digital services. Reach out and join
+            the effort.
+          </Text>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <a
+              href="mailto:volunteers@bettergov.ph"
+              className="inline-flex items-center justify-center px-5 py-2.5 text-sm font-semibold text-white bg-primary-600 rounded-xl hover:bg-primary-500 transition-colors"
+            >
+              Email Us
+            </a>
+            <a
+              href="https://github.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center px-5 py-2.5 text-sm font-semibold text-primary-700 border border-primary-200 bg-primary-50 rounded-xl hover:bg-primary-100 transition-colors"
+            >
+              Open an Issue on GitHub
+            </a>
           </div>
         </div>
       </Section>

--- a/src/pages/about/BetterGov.tsx
+++ b/src/pages/about/BetterGov.tsx
@@ -1,0 +1,71 @@
+import SEO from '../../components/SEO';
+import Section from '../../components/ui/Section';
+import { Heading } from '../../components/ui/Heading';
+import { Text } from '../../components/ui/Text';
+import Breadcrumbs from '../../components/ui/Breadcrumbs';
+
+const breadcrumbs = [
+  { label: 'Home', href: '/' },
+  { label: 'About', href: '/about/bettergov' },
+  { label: 'BetterGov', href: '/about/bettergov' },
+];
+
+const AboutBetterGov: React.FC = () => {
+  return (
+    <>
+      <SEO
+        title="About BetterGov"
+        description="Learn about the BetterGov initiative and the BetterLGU project."
+        keywords="BetterGov, BetterLGU, local government, civic technology, Philippines"
+      />
+      <Section className="py-12">
+        <Breadcrumbs className="mb-8" items={breadcrumbs} />
+
+        {/* Hero / Introduction */}
+        <div className="mb-12">
+          <Heading level={1}>About BetterGov</Heading>
+          <Text className="max-w-2xl mt-4 text-gray-600">
+            TODO: What BetterGov is and the BetterLGU initiative.
+          </Text>
+        </div>
+
+        {/* Mission and Goals */}
+        <div className="mb-12">
+          <Heading level={2}>Mission and Goals</Heading>
+          <Text className="mt-4 text-gray-600">
+            TODO: Mission and goals of BetterGov.
+          </Text>
+        </div>
+
+        {/* Why It Was Created */}
+        <div className="mb-12">
+          <Heading level={2}>Why It Was Created</Heading>
+          <Text className="mt-4 text-gray-600">
+            TODO: Why BetterGov was created.
+          </Text>
+        </div>
+
+        {/* How LGUs and Citizens Benefit */}
+        <div className="mb-12">
+          <Heading level={2}>How It Helps</Heading>
+          <div className="grid grid-cols-1 gap-6 mt-4 sm:grid-cols-2">
+            <div className="p-6 border rounded-lg">
+              <Heading level={3}>For Local Governments</Heading>
+              <Text className="mt-2 text-gray-600">
+                TODO: How LGUs benefit.
+              </Text>
+            </div>
+            <div className="p-6 border rounded-lg">
+              <Heading level={3}>For Citizens</Heading>
+              <Text className="mt-2 text-gray-600">
+                TODO: How citizens benefit.
+              </Text>
+            </div>
+          </div>
+        </div>
+      </Section>
+    </>
+  );
+};
+
+export default AboutBetterGov;

--- a/src/pages/about/BetterGov.tsx
+++ b/src/pages/about/BetterGov.tsx
@@ -49,84 +49,95 @@ const AboutBetterGov: React.FC = () => {
           <Heading level={1} className="text-white">
             {data.name}
           </Heading>
-          <Text className="mt-4 text-primary-100 max-w-none sm:px-8 lg:px-16">
-            {data.tagline}
+          <Text className="mt-4 text-primary-100 max-w-none sm:px-8 lg:px-40">
+            {data.description}
           </Text>
         </div>
       </div>
 
       <Section className="p-1 px-6 mb-12 sm:px-10 lg:px-20 xl:px-30">
-        {/* What is BetterGov */}
+        {/* Mission — primary blue */}
         <div className="mb-12">
-          <Text className="text-lg leading-relaxed text-gray-700 max-w-none">
-            {data.description}
-          </Text>
+          <Heading level={2}>Our Mission</Heading>
+          <div className="mt-6 overflow-hidden border bg-primary-50 border-primary-100 rounded-xl">
+            <div className="p-8">
+              <div className="flex items-center gap-2 mb-4">
+                <div className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary-600">
+                  <svg
+                    className="w-4 h-4 text-white"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.562.562 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
+                    />
+                  </svg>
+                </div>
+                <Text className="text-sm font-bold tracking-wide uppercase text-primary-700 max-w-none">
+                  Core Objective
+                </Text>
+              </div>
+              <Text className="leading-relaxed text-gray-700 max-w-none">
+                {data.mission}
+              </Text>
+            </div>
+          </div>
         </div>
 
-        <hr className="mb-12 border-gray-200" />
-
-        {/* Mission */}
-        <div className="mb-10">
-          <div className="flex items-center gap-2 mb-2">
-            <span className="inline-block w-1 h-5 rounded-full bg-primary-500" />
-            <Text className="text-xs font-bold tracking-widest uppercase text-primary-500 max-w-none">
-              Our Mission
-            </Text>
+        {/* Why It Was Created — back to primary */}
+        <div className="mb-12">
+          <Heading level={2}>Why It Was Created</Heading>
+          <div className="mt-6 overflow-hidden border bg-primary-50 border-primary-100 rounded-xl">
+            <div className="p-8">
+              <div className="flex items-center gap-2 mb-4">
+                <div className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary-600">
+                  <svg
+                    className="w-4 h-4 text-white"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253M3 12c0 .778.099 1.533.284 2.253"
+                    />
+                  </svg>
+                </div>
+                <Text className="text-sm font-bold tracking-wide uppercase text-primary-700 max-w-none">
+                  The Purpose
+                </Text>
+              </div>
+              <Text className="leading-relaxed text-gray-700 max-w-none">
+                {data.why}
+              </Text>
+            </div>
           </div>
-          <Heading level={2} className="mb-3 text-gray-900">
-            What We&apos;re Here to Do
-          </Heading>
-          <Text className="leading-relaxed text-gray-600 max-w-none">
-            {data.mission}
-          </Text>
         </div>
 
-        {/* Why It Exists */}
+        {/* Who It's For — both cards primary */}
         <div className="mb-12">
-          <div className="flex items-center gap-2 mb-2">
-            <span className="inline-block w-1 h-5 rounded-full bg-primary-500" />
-            <Text className="text-xs font-bold tracking-widest uppercase text-primary-500 max-w-none">
-              Why It Exists
-            </Text>
-          </div>
-          <Heading level={2} className="mb-3 text-gray-900">
-            The Problem We&apos;re Solving
-          </Heading>
-          <Text className="leading-relaxed text-gray-600 max-w-none">
-            {data.why}
-          </Text>
-        </div>
-
-        <hr className="mb-12 border-gray-200" />
-
-        {/* Who It's For */}
-        <div className="mb-12">
-          <div className="flex items-center gap-2 mb-2">
-            <span className="inline-block w-1 h-5 rounded-full bg-primary-500" />
-            <Text className="text-xs font-bold tracking-widest uppercase text-primary-500 max-w-none">
-              Who It&apos;s For
-            </Text>
-          </div>
-          <Heading level={2} className="mb-6 text-gray-900">
-            Built for Every Filipino
-          </Heading>
-          <div className="flex flex-col gap-4 lg:flex-row">
+          <Heading level={2}>Who It&apos;s For</Heading>
+          <div className="grid grid-cols-1 gap-4 mt-6 sm:grid-cols-2">
             {data.benefits.map(benefit => {
               const Icon = resolveLucideIcon(benefit.icon);
               return (
                 <div
                   key={benefit.audience}
-                  className="flex flex-col gap-3 p-6 border border-primary-100 bg-primary-50 rounded-2xl lg:w-1/2"
+                  className="flex flex-col p-6 border shadow-sm rounded-xl bg-primary-50 border-primary-100"
                 >
-                  <div className="flex items-center gap-2">
-                    <div className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary-600 shrink-0">
-                      <Icon className="w-4 h-4 text-white" />
-                    </div>
-                    <Text className="font-semibold text-primary-800 max-w-none">
-                      {benefit.audience}
-                    </Text>
+                  <div className="inline-flex items-center justify-center flex-shrink-0 w-10 h-10 mb-4 rounded-lg bg-primary-600">
+                    <Icon className="w-6 h-6 text-white" />
                   </div>
-                  <Text className="text-sm leading-relaxed text-gray-600 max-w-none">
+                  <Text className="text-xl font-bold max-w-none text-primary-900">
+                    {benefit.audience}
+                  </Text>
+                  <Text className="mt-2 text-sm text-gray-600 max-w-none">
                     {benefit.description}
                   </Text>
                 </div>
@@ -135,38 +146,68 @@ const AboutBetterGov: React.FC = () => {
           </div>
         </div>
 
-        <hr className="mb-12 border-gray-200" />
-
-        {/* Get Involved */}
-        <div className="mb-4">
-          <div className="flex items-center gap-2 mb-2">
-            <span className="inline-block w-1 h-5 rounded-full bg-primary-500" />
-            <Text className="text-xs font-bold tracking-widest uppercase text-primary-500 max-w-none">
-              Get Involved
-            </Text>
-          </div>
-          <Heading level={2} className="mb-3 text-gray-900">
-            Help Us Build It
-          </Heading>
-          <Text className="mb-5 leading-relaxed text-gray-600 max-w-none">
+        {/* Get Involved — email and GitHub cards */}
+        <div className="mb-12">
+          <Heading level={2}>Get Involved</Heading>
+          <Text className="mt-2 mb-8 leading-relaxed text-gray-600 max-w-none">
             BetterGov is open to anyone who believes Filipinos deserve better
-            from their government&apos;s digital services. Reach out and join
-            the effort.
+            from their government&apos;s digital services.
           </Text>
-          <div className="flex flex-col gap-2 sm:flex-row">
+          <div className="grid gap-4 sm:grid-cols-2">
             <a
               href="mailto:volunteers@bettergov.ph"
-              className="inline-flex items-center justify-center px-5 py-2.5 text-sm font-semibold text-white bg-primary-600 rounded-xl hover:bg-primary-500 transition-colors"
+              className="flex flex-row items-center gap-5 p-6 text-white transition-colors bg-primary-600 rounded-2xl hover:bg-primary-500"
             >
-              Email Us
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-white/20 shrink-0">
+                <svg
+                  className="w-6 h-6 text-white"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0l-9.75 6.75L2.25 6.75"
+                  />
+                </svg>
+              </div>
+              <div className="text-left">
+                <Text className="font-semibold text-white max-w-none">
+                  Email Us
+                </Text>
+                <Text className="text-xs text-primary-100 max-w-none">
+                  Introduce yourself and tell us how you want to contribute to
+                  the project.
+                </Text>
+              </div>
             </a>
+
             <a
               href="https://github.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center justify-center px-5 py-2.5 text-sm font-semibold text-primary-700 border border-primary-200 bg-primary-50 rounded-xl hover:bg-primary-100 transition-colors"
+              className="flex flex-row items-center gap-5 p-6 transition-all bg-white border border-primary-200 rounded-2xl hover:border-primary-400 hover:shadow-md"
             >
-              Open an Issue on GitHub
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-primary-50 shrink-0">
+                <svg
+                  className="w-6 h-6 text-primary-600"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12z" />
+                </svg>
+              </div>
+              <div className="text-left">
+                <Text className="font-semibold text-primary-800 max-w-none">
+                  Open an Issue
+                </Text>
+                <Text className="text-xs text-gray-500 max-w-none">
+                  Have an idea or suggestion? Start the conversation on GitHub
+                  and help shape the project.
+                </Text>
+              </div>
             </a>
           </div>
         </div>

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,6 +1,5 @@
-import { Outlet, NavLink } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import SEO from '../../components/SEO';
-import Section from '../../components/ui/Section';
 
 const About: React.FC = () => {
   return (
@@ -11,38 +10,6 @@ const About: React.FC = () => {
         keywords="Allen, municipality, BetterGov, BetterLGU, local government"
       />
       <main className="grow">
-        {/* Sub-navigation */}
-        <div className="bg-white border-b border-gray-200">
-          <Section>
-            <nav className="flex gap-6">
-              <NavLink
-                to="/about/allen"
-                className={({ isActive }) =>
-                  `py-3 text-sm font-medium border-b-2 transition-colors ${
-                    isActive
-                      ? 'border-primary-600 text-primary-600'
-                      : 'border-transparent text-gray-600 hover:text-primary-600'
-                  }`
-                }
-              >
-                About Allen
-              </NavLink>
-              <NavLink
-                to="/about/bettergov"
-                className={({ isActive }) =>
-                  `py-3 text-sm font-medium border-b-2 transition-colors ${
-                    isActive
-                      ? 'border-primary-600 text-primary-600'
-                      : 'border-transparent text-gray-600 hover:text-primary-600'
-                  }`
-                }
-              >
-                About BetterGov
-              </NavLink>
-            </nav>
-          </Section>
-        </div>
-
         {/* Child route renders here */}
         <Outlet />
       </main>

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,0 +1,53 @@
+import { Outlet, NavLink } from 'react-router-dom';
+import SEO from '../../components/SEO';
+import Section from '../../components/ui/Section';
+
+const About: React.FC = () => {
+  return (
+    <>
+      <SEO
+        title="About"
+        description="Learn about Allen municipality and the BetterGov initiative."
+        keywords="Allen, municipality, BetterGov, BetterLGU, local government"
+      />
+      <main className="grow">
+        {/* Sub-navigation */}
+        <div className="bg-white border-b border-gray-200">
+          <Section>
+            <nav className="flex gap-6">
+              <NavLink
+                to="/about/allen"
+                className={({ isActive }) =>
+                  `py-3 text-sm font-medium border-b-2 transition-colors ${
+                    isActive
+                      ? 'border-primary-600 text-primary-600'
+                      : 'border-transparent text-gray-600 hover:text-primary-600'
+                  }`
+                }
+              >
+                About Allen
+              </NavLink>
+              <NavLink
+                to="/about/bettergov"
+                className={({ isActive }) =>
+                  `py-3 text-sm font-medium border-b-2 transition-colors ${
+                    isActive
+                      ? 'border-primary-600 text-primary-600'
+                      : 'border-transparent text-gray-600 hover:text-primary-600'
+                  }`
+                }
+              >
+                About BetterGov
+              </NavLink>
+            </nav>
+          </Section>
+        </div>
+
+        {/* Child route renders here */}
+        <Outlet />
+      </main>
+    </>
+  );
+};
+
+export default About;


### PR DESCRIPTION
Closes #4

## What's changed
- Added `/about`, `/about/allen`, and `/about/bettergov` routes
- About Allen page includes description, key statistics, history timeline, and geography with map
- About BetterGov page includes description, mission, why it was created, who it's for, and get involved section
- Added About section on the homepage with brief cards linking to both subpages
- About entry added to main navigation with dropdown for both subroutes
- All content is driven by YAML files for easy non-technical editing
- SEO metadata added to all About pages

## Notes
- Content for both pages is in `src/data/about_allen.yaml` and `src/data/about_bettergov.yaml`
- Homepage About section pulls directly from the same YAML files