### PR TITLE
refactor: About page restructuring and content update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,13 +9,16 @@ import Document from './pages/Document';
 import Government from './pages/Government';
 import { Toaster } from './components/ui/sonner';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import About from './pages/about'; // the index.tsx
+import AboutAllen from './pages/about/Allen';
+import AboutBetterGov from './pages/about/BetterGov';
 
 function App() {
   return (
     <HelmetProvider>
       <Router>
         <NuqsAdapter>
-          <div className="min-h-screen flex flex-col">
+          <div className="flex flex-col min-h-screen">
             <Navbar />
             <ScrollToTop />
             <Routes>
@@ -32,6 +35,11 @@ function App() {
                 path="/government/:category/:documentSlug"
                 element={<Document categoryType="government" />}
               />
+              <Route path="/about" element={<About />}>
+                <Route index element={<AboutAllen />} />
+                <Route path="allen" element={<AboutAllen />} />
+                <Route path="bettergov" element={<AboutBetterGov />} />
+              </Route>
               <Route path="/:lang/:documentSlug" element={<Document />} />
               <Route path="/:documentSlug" element={<Document />} />
             </Routes>

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -9,11 +9,13 @@ interface AllenData {
   name: string;
   province: string;
   description: string;
+  card_description: string;
 }
 
 interface BetterGovData {
   name: string;
   description: string;
+  card_description: string;
 }
 
 const allen = yaml.load(allenYaml) as AllenData;
@@ -21,8 +23,8 @@ const bettergov = yaml.load(betterGovYaml) as BetterGovData;
 
 const AboutSection: React.FC = () => {
   return (
-    <section className="px-6 py-16 bg-gray-50 sm:px-10 lg:px-20 xl:px-30">
-      <div className="mb-10">
+    <section className="px-4 py-12 bg-gray-50 sm:px-10 lg:px-20 xl:px-30">
+      <div className="mb-8">
         <Text className="mb-1 text-xs font-bold tracking-widest uppercase text-primary-500 max-w-none">
           Get to Know Us
         </Text>
@@ -35,7 +37,7 @@ const AboutSection: React.FC = () => {
         </Text>
       </div>
 
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div className="flex flex-col gap-4 sm:grid sm:grid-cols-2 sm:gap-6">
         {/* Allen Card */}
         <div className="flex flex-col justify-between p-8 transition-all duration-200 bg-white border border-gray-200 shadow-sm rounded-2xl hover:border-primary-300 hover:shadow-md">
           <div>
@@ -63,7 +65,7 @@ const AboutSection: React.FC = () => {
               {allen.name}, {allen.province}
             </Heading>
             <Text className="text-sm leading-relaxed text-gray-500 max-w-none">
-              {allen.description}
+              {allen.card_description}
             </Text>
           </div>
           <Link
@@ -109,7 +111,7 @@ const AboutSection: React.FC = () => {
               {bettergov.name}
             </Heading>
             <Text className="text-sm leading-relaxed text-primary-100 max-w-none">
-              {bettergov.description}
+              {bettergov.card_description}
             </Text>
           </div>
           <Link

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -1,0 +1,140 @@
+import { Link } from 'react-router-dom';
+import { Heading } from '../ui/Heading';
+import { Text } from '../ui/Text';
+import yaml from 'js-yaml';
+import allenYaml from '../../data/about_allen.yaml?raw';
+import betterGovYaml from '../../data/about_bettergov.yaml?raw';
+
+interface AllenData {
+  name: string;
+  province: string;
+  description: string;
+}
+
+interface BetterGovData {
+  name: string;
+  description: string;
+}
+
+const allen = yaml.load(allenYaml) as AllenData;
+const bettergov = yaml.load(betterGovYaml) as BetterGovData;
+
+const AboutSection: React.FC = () => {
+  return (
+    <section className="px-6 py-16 bg-gray-50 sm:px-10 lg:px-20 xl:px-30">
+      <div className="mb-10">
+        <Text className="mb-1 text-xs font-bold tracking-widest uppercase text-primary-500 max-w-none">
+          Get to Know Us
+        </Text>
+        <Heading level={2} className="text-gray-900">
+          About Allen &amp; BetterGov
+        </Heading>
+        <Text className="mt-2 text-gray-500 max-w-none">
+          Learn about the municipality behind this website and the volunteer
+          initiative that built it.
+        </Text>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        {/* Allen Card */}
+        <div className="flex flex-col justify-between p-8 transition-all duration-200 bg-white border border-gray-200 shadow-sm rounded-2xl hover:border-primary-300 hover:shadow-md">
+          <div>
+            <div className="inline-flex items-center justify-center w-10 h-10 mb-5 rounded-xl bg-primary-600">
+              <svg
+                className="w-5 h-5 text-white"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z"
+                />
+              </svg>
+            </div>
+            <Heading level={3} className="mb-2 text-gray-900">
+              {allen.name}, {allen.province}
+            </Heading>
+            <Text className="text-sm leading-relaxed text-gray-500 max-w-none">
+              {allen.description}
+            </Text>
+          </div>
+          <Link
+            to="/about/allen"
+            className="inline-flex items-center gap-2 mt-6 text-sm font-semibold transition-colors text-primary-600 hover:text-primary-500"
+          >
+            Learn about Allen
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
+              />
+            </svg>
+          </Link>
+        </div>
+
+        {/* BetterGov Card */}
+        <div className="flex flex-col justify-between p-8 transition-all duration-200 border shadow-sm bg-primary-600 border-primary-700 rounded-2xl hover:bg-primary-500">
+          <div>
+            <div className="inline-flex items-center justify-center w-10 h-10 mb-5 rounded-xl bg-white/20">
+              <svg
+                className="w-5 h-5 text-white"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253M3 12c0 .778.099 1.533.284 2.253"
+                />
+              </svg>
+            </div>
+            <Heading level={3} className="mb-2 text-white">
+              {bettergov.name}
+            </Heading>
+            <Text className="text-sm leading-relaxed text-primary-100 max-w-none">
+              {bettergov.description}
+            </Text>
+          </div>
+          <Link
+            to="/about/bettergov"
+            className="inline-flex items-center gap-2 mt-6 text-sm font-semibold text-white transition-colors hover:text-primary-100"
+          >
+            Learn about BetterGov
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
+              />
+            </svg>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default AboutSection;

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -247,15 +247,15 @@ const Navbar: React.FC = () => {
   };
 
   return (
-    <nav className="bg-white shadow-sm sticky top-0 z-50">
+    <nav className="sticky top-0 z-50 bg-white shadow-sm">
       {/* Top bar with hotlines */}
       <div
         className={` bg-red-600  transition-all duration-200 overflow-hidden  ${
           isScrolled ? 'max-h-0' : 'max-h-10'
         }`}
       >
-        <div className="mx-auto flex justify-end items-center h-10">
-          <div className="slideshow w-full" ref={hotlineViewportRef}>
+        <div className="flex items-center justify-end h-10 mx-auto">
+          <div className="w-full slideshow" ref={hotlineViewportRef}>
             {/* Measure the width of hotline items for scrolling effect */}
             <div className="slideshow-measure" ref={hotlineMeasureRef}>
               {hotlinesData.hotlines.map(hotline => {
@@ -264,9 +264,9 @@ const Navbar: React.FC = () => {
                   <button
                     type="button"
                     key={`measure-${hotline.slug}`}
-                    className="shrink-0 flex text-nowrap text-white text-sm bg-slate-200/20 px-2 py-1 rounded-md items-center gap-1"
+                    className="flex items-center gap-1 px-2 py-1 text-sm text-white rounded-md shrink-0 text-nowrap bg-slate-200/20"
                   >
-                    <Icon className="h-4 w-4" />
+                    <Icon className="w-4 h-4" />
                     <span>{hotline.name}: </span>
                     <span className="font-mono">{hotline.number}</span>
                   </button>
@@ -290,7 +290,7 @@ const Navbar: React.FC = () => {
                     onClick={() => copyHotlineNumber(hotline.number)}
                     className="shrink-0 flex text-nowrap text-white text-sm hover:bg-slate-200/50 hover:-translate-y-0.5 transition-all bg-slate-200/20 px-2 py-1 rounded-md items-center gap-1"
                   >
-                    <Icon className="h-4 w-4" />
+                    <Icon className="w-4 h-4" />
                     <span>{hotline.name}: </span>
                     <span className="font-mono">{hotline.number}</span>
                   </button>
@@ -307,8 +307,8 @@ const Navbar: React.FC = () => {
           isScrolled ? 'max-h-0' : 'max-h-14'
         }`}
       >
-        <div className="container mx-auto px-4 py-2">
-          <div className="flex items-center justify-end text-white text-sm gap-4">
+        <div className="container px-4 py-2 mx-auto">
+          <div className="flex items-center justify-end gap-4 text-sm text-white">
             <div key={currentCurrencyIndex} className="animate-fade-in">
               <Text size="xs">
                 {(() => {
@@ -326,19 +326,19 @@ const Navbar: React.FC = () => {
               </Text>
             </div>
 
-            <span className="inline text-gray-500 text-xs">|</span>
+            <span className="inline text-xs text-gray-500">|</span>
             <Text size="xs" className="flex items-center gap-1">
-              <Thermometer className="h-4 w-4 inline" />{' '}
-              <span className="font-extralight text-gray-400">Allen</span>{' '}
+              <Thermometer className="inline w-4 h-4" />{' '}
+              <span className="text-gray-400 font-extralight">Allen</span>{' '}
               {temperature}°C
             </Text>
 
-            <span className="hidden sm:inline text-gray-500 text-xs">|</span>
+            <span className="hidden text-xs text-gray-500 sm:inline">|</span>
             <Text
               size="xs"
-              className="items-center gap-1 font-mono hidden sm:inline-flex"
+              className="items-center hidden gap-1 font-mono sm:inline-flex"
             >
-              <Clock className="h-3 w-3 inline" />{' '}
+              <Clock className="inline w-3 h-3" />{' '}
               {(() => {
                 const dateStr = currentTime.toLocaleString('en-US', {
                   month: 'short',
@@ -361,18 +361,18 @@ const Navbar: React.FC = () => {
       </div>
 
       {/* Main navigation */}
-      <div className="container mx-auto px-4">
-        <div className="flex justify-between items-center py-4">
+      <div className="container px-4 mx-auto">
+        <div className="flex items-center justify-between py-4">
           <div className="flex items-center">
             <Link to="/" className="flex items-center">
-              <CheckCircle2 className="h-12 w-12 mr-3" />
+              <CheckCircle2 className="w-12 h-12 mr-3" />
               {/* <img
                 src="/ph-logo.webp"
                 alt="Philippines Coat of Arms"
-                className="h-12 w-12 mr-3"
+                className="w-12 h-12 mr-3"
               /> */}
               <div>
-                <div className="text-black font-bold">
+                <div className="font-bold text-black">
                   {import.meta.env.VITE_GOVERNMENT_NAME}
                 </div>
                 <div className="text-xs text-gray-800">
@@ -383,7 +383,7 @@ const Navbar: React.FC = () => {
           </div>
 
           {/* Desktop navigation */}
-          <div className="hidden lg:flex items-center space-x-8 pr-24">
+          <div className="items-center hidden pr-24 space-x-8 lg:flex">
             {/* Main navigation items with dropdowns */}
             {mainNavigation.map(item => (
               <div key={item.label} className="relative group">
@@ -397,11 +397,11 @@ const Navbar: React.FC = () => {
                 >
                   {t(`navbar.${item.label.replace(' ', '').toLowerCase()}`)}
                   {item.children && (
-                    <ChevronDown className="ml-1 h-4 w-4 text-gray-800 group-hover:text-primary-600 transition-colors" />
+                    <ChevronDown className="w-4 h-4 ml-1 text-gray-800 transition-colors group-hover:text-primary-600" />
                   )}
                 </a>
                 {item.children && (
-                  <div className="absolute left-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
+                  <div className="absolute left-0 z-50 invisible w-56 mt-2 transition-all duration-200 bg-white rounded-md shadow-lg opacity-0 ring-1 ring-black ring-opacity-5 group-hover:opacity-100 group-hover:visible">
                     <div
                       className="py-1"
                       role="menu"
@@ -411,7 +411,7 @@ const Navbar: React.FC = () => {
                         <Link
                           key={child.label}
                           to={child.href}
-                          className="text-left block px-4 py-2 text-sm text-gray-700 hover:bg-primary-50 hover:text-primary-600"
+                          className="block px-4 py-2 text-sm text-left text-gray-700 hover:bg-primary-50 hover:text-primary-600"
                           role="menuitem"
                         >
                           {t(
@@ -426,28 +426,28 @@ const Navbar: React.FC = () => {
               </div>
             ))}
           </div>
-          <div className="hidden lg:flex items-center space-x-6">
+          <div className="items-center hidden space-x-6 lg:flex">
             <LanguageSwitcher />
 
             {/* <Link
               to="/sitemap"
-              className="flex items-center text-gray-700 hover:text-primary-600 font-medium transition-colors"
+              className="flex items-center font-medium text-gray-700 transition-colors hover:text-primary-600"
             >
               Sitemap
             </Link> */}
           </div>
 
           {/* Mobile menu button */}
-          <div className="lg:hidden flex items-center">
+          <div className="flex items-center lg:hidden">
             <button
               onClick={toggleMenu}
-              className="inline-flex items-center justify-center p-2 rounded-md text-gray-700 hover:text-primary-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500"
+              className="inline-flex items-center justify-center p-2 text-gray-700 rounded-md hover:text-primary-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500"
             >
               <span className="sr-only">Open main menu</span>
               {isOpen ? (
-                <X className="block h-6 w-6" aria-hidden="true" />
+                <X className="block w-6 h-6" aria-hidden="true" />
               ) : (
-                <Menu className="block h-6 w-6" aria-hidden="true" />
+                <Menu className="block w-6 h-6" aria-hidden="true" />
               )}
             </button>
           </div>
@@ -456,43 +456,59 @@ const Navbar: React.FC = () => {
 
       {/* Mobile menu */}
       <div className={`lg:hidden ${isOpen ? 'block' : 'hidden'}`}>
-        <div className="container mx-auto px-2 pt-2 pb-4 space-y-1 border-t border-gray-200 bg-white">
+        <div className="container px-2 pt-2 pb-4 mx-auto space-y-1 bg-white border-t border-gray-200">
           {/* Main navigation items with mobile submenu */}
           {mainNavigation.map(item => (
             <div key={item.label}>
-              <button
-                onClick={() => toggleSubmenu(item.label)}
-                className={`w-full flex justify-between items-center px-4 py-2 text-base font-medium transition-colors ${
-                  isActivePage(item.href)
-                    ? 'bg-primary-50 text-primary-600'
-                    : 'text-gray-700 hover:bg-gray-50 hover:text-primary-500'
-                }`}
-              >
-                {t(`navbar.${item.label.toLowerCase()}`)}
-                {item.children && (
-                  <ChevronDown
-                    className={`h-5 w-5 transition-transform ${
-                      activeMenu === item.label ? 'transform rotate-180' : ''
+              {item.children ? (
+                <>
+                  <button
+                    onClick={() => toggleSubmenu(item.label)}
+                    className={`w-full flex justify-between items-center px-4 py-2 text-base font-medium transition-colors ${
+                      isActivePage(item.href)
+                        ? 'bg-primary-50 text-primary-600'
+                        : 'text-gray-700 hover:bg-gray-50 hover:text-primary-500'
                     }`}
-                  />
-                )}
-              </button>
-              {/* Submenu for mobile */}
-              {item.children && activeMenu === item.label && (
-                <div className="pl-6 py-2 space-y-1 bg-gray-50">
-                  {item.children.map(child => (
-                    <Link
-                      key={child.label}
-                      to={child.href}
-                      onClick={closeMenu}
-                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-primary-500"
-                    >
-                      {t(`services.${child.href.split('/').pop()}.category`, {
-                        defaultValue: child.label,
-                      })}
-                    </Link>
-                  ))}
-                </div>
+                  >
+                    {t(`navbar.${item.label.toLowerCase()}`)}
+                    <ChevronDown
+                      className={`h-5 w-5 transition-transform ${
+                        activeMenu === item.label ? 'transform rotate-180' : ''
+                      }`}
+                    />
+                  </button>
+                  {activeMenu === item.label && (
+                    <div className="py-2 pl-6 space-y-1 bg-gray-50">
+                      {item.children.map(child => (
+                        <Link
+                          key={child.label}
+                          to={child.href}
+                          onClick={closeMenu}
+                          className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-primary-500"
+                        >
+                          {t(
+                            `services.${child.href.split('/').pop()}.category`,
+                            {
+                              defaultValue: child.label,
+                            }
+                          )}
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <Link
+                  to={item.href}
+                  onClick={closeMenu}
+                  className={`w-full flex items-center px-4 py-2 text-base font-medium transition-colors ${
+                    isActivePage(item.href)
+                      ? 'bg-primary-50 text-primary-600'
+                      : 'text-gray-700 hover:bg-gray-50 hover:text-primary-500'
+                  }`}
+                >
+                  {t(`navbar.${item.label.toLowerCase()}`)}
+                </Link>
               )}
             </div>
           ))}

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -10,7 +10,7 @@ export default function Section({
 }) {
   return (
     <section className={cn('py-12 bg-white', className)} id={id}>
-      <div className="max-w-7xl mx-auto px-6">{children}</div>
+      <div className="px-4 mx-auto max-w-7xl sm:px-6">{children}</div>
     </section>
   );
 }

--- a/src/data/about_allen.yaml
+++ b/src/data/about_allen.yaml
@@ -22,15 +22,6 @@ geography: >
   land spans a flat coastal shoreline that rises into rolling hills inland,
   with 20 barangays spread along the coast and further inland.
 
-economy: >
-  Allen's economy is anchored by fishing and the movement of goods and people through its
-  port. The San Bernardino Strait provides rich fishing grounds, and many residents make
-  their living from the sea — supplying local markets and nearby towns with fresh catch.
-  The RoRo (Roll-on/Roll-off) ferry terminal connecting Allen to Matnog, Sorsogon drives
-  consistent commercial activity: transport services, small trading, eateries, and informal
-  vendors all cluster around the port area. Agriculture — primarily coconut farming and
-  rice — supplements livelihoods further inland.
-
 stats:
   - label: Population
     value: "26,527"

--- a/src/data/about_allen.yaml
+++ b/src/data/about_allen.yaml
@@ -77,3 +77,8 @@ timeline:
     event: >
       Allen continues to grow as both a transit hub and a home to over 26,000
       residents across 20 barangays.
+
+card_description: >
+  The southern gateway between Luzon and the Visayas — a coastal municipality
+  defined by the sea, the San Bernardino Strait, and the constant movement of
+  people passing through.

--- a/src/data/about_allen.yaml
+++ b/src/data/about_allen.yaml
@@ -1,0 +1,88 @@
+# Allen Municipality Data
+# Non-technical contributors can edit this file to update content on the About Allen page.
+
+name: Allen
+province: Northern Samar
+region: Eastern Visayas
+
+description: >
+  Allen is a coastal municipality in Northern Samar — the southern gateway between Luzon
+  and the Visayas, where the San Bernardino Strait narrows and every journey south begins.
+
+history: >
+  Long before the Spanish arrived, these shores were already home to Austronesian settlers,
+  who called it Minapa-a. Under Spanish colonial rule, the area was formally established as
+  a town and named La Granja, then later renamed Allen under American rule. Through every
+  change of name and ruler, the town has remained a place defined by the constant movement
+  of people and sea.
+
+geography: >
+  Allen sits at the northern tip of Samar, facing the San Bernardino Strait,
+  the natural crossing point between Luzon and the Visayas. Its 47.60 km² of
+  land spans a flat coastal shoreline that rises into rolling hills inland,
+  with 20 barangays spread along the coast and further inland.
+
+economy: >
+  Allen's economy is anchored by fishing and the movement of goods and people through its
+  port. The San Bernardino Strait provides rich fishing grounds, and many residents make
+  their living from the sea — supplying local markets and nearby towns with fresh catch.
+  The RoRo (Roll-on/Roll-off) ferry terminal connecting Allen to Matnog, Sorsogon drives
+  consistent commercial activity: transport services, small trading, eateries, and informal
+  vendors all cluster around the port area. Agriculture — primarily coconut farming and
+  rice — supplements livelihoods further inland.
+
+stats:
+  - label: Population
+    value: "26,527"
+    sublabel: Population (2025 Census)
+    icon: Users
+
+  - label: Barangays
+    value: "20"
+    sublabel: Administrative divisions
+    asOf: As of 2025
+    icon: MapPin
+
+  - label: Land Area
+    value: 47.60 km²
+    sublabel: Total municipal coverage
+    asOf: As of 2025
+    icon: Map
+
+  - label: Founded
+    value: Dec. 1, 1863
+    sublabel: Date of establishment
+    icon: Award
+
+timeline:
+  - year: Pre-1863
+    event: >
+      Austronesian settlers establish communities along the San Bernardino Strait,
+      sustaining themselves through fishing and inter-island trade. The area is
+      known as Minapa-a.
+
+  - year: 1863
+    event: >
+      The Spanish formally establish a town on these shores, naming it La Granja.
+      It marks the beginning of organized colonial administration in the area.
+
+  - year: 1903
+    event: >
+      American colonial rule renames the town Allen, in honor of General Henry T.
+      Allen, military governor of the Visayas. Civil governance structures are
+      reorganized under the new administration.
+
+  - year: 1942–1945
+    event: >
+      During the Japanese occupation, the town is briefly renamed Tanaman.
+      Post-war reconstruction gradually restores and reshapes the town center.
+
+  - year: 1950s–1970s
+    event: >
+      The ferry route between Allen and Matnog formalizes, cementing Allen's role
+      as the primary gateway between Luzon and the Visayas.
+
+  - year: Present
+    event: >
+      Allen continues to grow as both a transit hub and a home to over 26,000
+      residents across 20 barangays.

--- a/src/data/about_bettergov.yaml
+++ b/src/data/about_bettergov.yaml
@@ -1,0 +1,35 @@
+# BetterGov Initiative Data
+# Non-technical contributors can edit this file to update content on the About BetterGov page.
+
+name: BetterGov
+tagline: A Better Philippine Government Website
+url: https://bettergov.ph
+
+description: >
+  BetterGov is a volunteer project by Filipinos, for Filipinos — built on the belief
+  that government information should be easy to find, easy to understand, and available
+  to everyone.
+
+mission: >
+  BetterGov exists to make government information more accessible and more human.
+  The project is open to anyone who wants to help — developers, writers, designers,
+  and everyday citizens who believe public services should work for the public.
+
+why: >
+  Good governance starts with good communication. BetterGov was created to bridge
+  the gap between government services and the people who need them — making it easier
+  for every Filipino to understand their rights, access public services, and stay
+  informed about what their government is doing.
+
+benefits:
+  - audience: For Citizens
+    icon: Users
+    description: >
+      Clear, accessible, and up-to-date government information — so any Filipino can
+      find what they need quickly, without confusion or dead ends.
+
+  - audience: For Local Governments
+    icon: Landmark
+    description: >
+      A modern, open-source model that any LGU can learn from or build on to improve
+      their own digital presence and better serve their constituents.

--- a/src/data/about_bettergov.yaml
+++ b/src/data/about_bettergov.yaml
@@ -33,3 +33,7 @@ benefits:
     description: >
       A modern, open-source model that any LGU can learn from or build on to improve
       their own digital presence and better serve their constituents.
+
+card_description: >
+  A volunteer project by Filipinos, for Filipinos — built to make government
+  information easy to find, easy to understand, and available to everyone.

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -32,6 +32,10 @@ export const mainNavigation: NavigationItem[] = [
   {
     label: 'About',
     href: '/about',
+    children: [
+      { label: 'Allen', href: '/about/allen' },
+      { label: 'BetterGov', href: '/about/bettergov' },
+    ],
   },
 ];
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import Hero from '../components/sections/Hero';
 import ServicesSection from '../components/home/ServicesSection';
 import GovernmentActivitySection from '../components/home/GovernmentActivitySection';
+import AboutSection from '../components/home/AboutSection';
 import SEO from '../components/SEO';
 
 const Home: React.FC = () => {
@@ -15,6 +16,7 @@ const Home: React.FC = () => {
         <Hero />
         <ServicesSection />
         <GovernmentActivitySection />
+        <AboutSection />
       </main>
     </>
   );

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -64,7 +64,7 @@ const AboutAllen: React.FC = () => {
         </div>
       </div>
 
-      <Section className="p-1 px-6 mb-12 sm:px-10 lg:px-20 xl:px-30">
+      <Section className="mb-12 sm:px-10 lg:px-20 xl:px-30">
         {/* Key Statistics */}
         <div className="mb-5">
           <div className="grid grid-cols-2 gap-4 p-2 sm:flex sm:flex-row sm:justify-center">

--- a/src/pages/about/Allen.tsx
+++ b/src/pages/about/Allen.tsx
@@ -1,0 +1,184 @@
+import SEO from '../../components/SEO';
+import Section from '../../components/ui/Section';
+import { Heading } from '../../components/ui/Heading';
+import { Text } from '../../components/ui/Text';
+import Breadcrumbs from '../../components/ui/Breadcrumbs';
+import { resolveLucideIcon } from '../../lib/utils';
+import yaml from 'js-yaml';
+import allenYaml from '../../data/about_allen.yaml?raw';
+
+interface Stat {
+  label: string;
+  value: string;
+  sublabel?: string;
+  asOf?: string;
+  icon?: string;
+}
+
+interface TimelineEntry {
+  year: string;
+  event: string;
+}
+
+interface AllenData {
+  name: string;
+  province: string;
+  description: string;
+  history: string;
+  geography: string;
+  economy: string;
+  stats: Stat[];
+  timeline: TimelineEntry[];
+}
+
+const data = yaml.load(allenYaml) as AllenData;
+
+const breadcrumbs = [
+  { label: 'Home', href: '/' },
+  { label: 'About', href: '/about' },
+  { label: 'Allen', href: '/about/allen' },
+];
+
+const AboutAllen: React.FC = () => {
+  return (
+    <>
+      <SEO
+        title={`About ${data.name}`}
+        description={data.description}
+        keywords={`${data.name}, ${data.province}, municipality, history, Philippines`}
+      />
+
+      {/* Blue hero banner */}
+      <div className="py-12 text-white bg-linear-to-r from-primary-600 to-primary-700">
+        <div className="container px-6 mx-auto text-center sm:px-12 lg:px-20">
+          <Breadcrumbs
+            className="justify-center mb-6 text-white"
+            items={breadcrumbs}
+          />
+          <Heading level={1} className="text-white">
+            {data.name}, {data.province}
+          </Heading>
+          <Text className="mt-4 text-primary-100 max-w-none sm:px-8 lg:px-40">
+            {data.description}
+          </Text>
+        </div>
+      </div>
+
+      <Section className="p-1 px-6 mb-12 sm:px-10 lg:px-20 xl:px-30">
+        {/* Key Statistics */}
+        <div className="mb-5">
+          <div className="grid grid-cols-2 gap-4 p-2 sm:flex sm:flex-row sm:justify-center">
+            {data.stats.map(stat => {
+              const Icon = resolveLucideIcon(stat.icon);
+              return (
+                <div
+                  key={stat.label}
+                  className="flex flex-col items-center justify-center gap-2 px-6 py-4 bg-white border shadow-sm rounded-xl sm:gap-0 sm:w-44 sm:h-44 lg:w-56 lg:h-48"
+                >
+                  <div className="inline-flex items-center justify-center flex-shrink-0 w-10 h-10 rounded-lg bg-primary-50 sm:mb-4">
+                    <Icon className="w-6 h-6 text-primary-600" />
+                  </div>
+                  <div className="text-center">
+                    <Text
+                      className={`font-bold text-blue-900 max-w-none ${
+                        stat.value.length > 6 ? 'text-sm' : 'text-xl'
+                      }`}
+                    >
+                      {stat.value}
+                    </Text>
+                    <Text className="mt-0.5 text-sm font-medium text-gray-600 max-w-none">
+                      {stat.label}
+                    </Text>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* History */}
+        <div className="mb-12">
+          <Heading level={2}>History</Heading>
+          <Text className="mt-2 mb-8 text-gray-500 max-w-none">
+            {data.history}
+          </Text>
+
+          <div className="relative pl-8 space-y-6 border-l-2 border-primary-200">
+            {data.timeline.map(entry => (
+              <div key={entry.year} className="relative">
+                <div className="absolute -left-[2.35rem] top-1.5 w-4 h-4 rounded-full bg-primary-500 border-4 border-white ring-2 ring-primary-300" />
+                <div className="p-4 transition-all duration-200 bg-white border border-gray-200 shadow-sm rounded-xl hover:border-primary-400 hover:shadow-md">
+                  <Text className="mb-1 text-sm font-bold text-primary-600 max-w-none">
+                    {entry.year}
+                  </Text>
+                  <Text className="text-sm text-gray-600 max-w-none">
+                    {entry.event}
+                  </Text>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Geography */}
+        <div className="mb-12">
+          <Heading level={2}>Geography</Heading>
+
+          <div className="mt-6">
+            {/* Unified Container */}
+            <div className="overflow-hidden border bg-primary-50 border-primary-100 rounded-xl">
+              <div className="flex flex-col lg:flex-row">
+                {/* Description Side */}
+                <div className="p-8 lg:w-1/2">
+                  <div className="flex items-center gap-2 mb-4">
+                    <div className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary-600">
+                      <svg
+                        className="w-4 h-4 text-white"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                        />
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                        />
+                      </svg>
+                    </div>
+                    <Text className="text-sm font-bold tracking-wide uppercase text-primary-700">
+                      Northern Samar, Eastern Visayas
+                    </Text>
+                  </div>
+                  <Text className="leading-relaxed text-gray-700 max-w-none">
+                    {data.geography}
+                  </Text>
+                </div>
+
+                {/* Integrated Map Side */}
+                <div className="relative flex items-stretch p-4 lg:p-6 lg:w-1/2">
+                  <div className="relative w-full overflow-hidden bg-white border shadow-inner rounded-xl border-primary-200/50">
+                    <iframe
+                      title="Allen, Northern Samar Map"
+                      src="https://maps.google.com/maps?q=12.5,124.282&z=14&output=embed"
+                      className="w-full h-80 lg:h-full min-h-[300px]"
+                      loading="lazy"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Section>
+    </>
+  );
+};
+
+export default AboutAllen;

--- a/src/pages/about/BetterGov.tsx
+++ b/src/pages/about/BetterGov.tsx
@@ -1,0 +1,219 @@
+import SEO from '../../components/SEO';
+import Section from '../../components/ui/Section';
+import { Heading } from '../../components/ui/Heading';
+import { Text } from '../../components/ui/Text';
+import Breadcrumbs from '../../components/ui/Breadcrumbs';
+import { resolveLucideIcon } from '../../lib/utils';
+import yaml from 'js-yaml';
+import betterGovYaml from '../../data/about_bettergov.yaml?raw';
+
+interface Benefit {
+  audience: string;
+  icon?: string;
+  description: string;
+}
+
+interface BetterGovData {
+  name: string;
+  tagline: string;
+  description: string;
+  mission: string;
+  why: string;
+  benefits: Benefit[];
+}
+
+const data = yaml.load(betterGovYaml) as BetterGovData;
+
+const breadcrumbs = [
+  { label: 'Home', href: '/' },
+  { label: 'About', href: '/about' },
+  { label: 'BetterGov', href: '/about/bettergov' },
+];
+
+const AboutBetterGov: React.FC = () => {
+  return (
+    <>
+      <SEO
+        title={`About ${data.name}`}
+        description={data.description}
+        keywords="BetterGov, BetterLGU, local government, civic technology, Philippines"
+      />
+
+      {/* Blue hero banner */}
+      <div className="py-12 text-white bg-linear-to-r from-primary-600 to-primary-700">
+        <div className="container px-6 mx-auto text-center sm:px-12 lg:px-20">
+          <Breadcrumbs
+            className="justify-center mb-6 text-white"
+            items={breadcrumbs}
+          />
+          <Heading level={1} className="text-white">
+            {data.name}
+          </Heading>
+          <Text className="mt-4 text-primary-100 max-w-none sm:px-8 lg:px-40">
+            {data.description}
+          </Text>
+        </div>
+      </div>
+
+      <Section className="p-1 px-6 mb-12 sm:px-10 lg:px-20 xl:px-30">
+        {/* Mission — primary blue */}
+        <div className="mb-12">
+          <Heading level={2}>Our Mission</Heading>
+          <div className="mt-6 overflow-hidden border bg-primary-50 border-primary-100 rounded-xl">
+            <div className="p-8">
+              <div className="flex items-center gap-2 mb-4">
+                <div className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary-600">
+                  <svg
+                    className="w-4 h-4 text-white"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.562.562 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
+                    />
+                  </svg>
+                </div>
+                <Text className="text-sm font-bold tracking-wide uppercase text-primary-700 max-w-none">
+                  Core Objective
+                </Text>
+              </div>
+              <Text className="leading-relaxed text-gray-700 max-w-none">
+                {data.mission}
+              </Text>
+            </div>
+          </div>
+        </div>
+
+        {/* Why It Was Created — back to primary */}
+        <div className="mb-12">
+          <Heading level={2}>Why It Was Created</Heading>
+          <div className="mt-6 overflow-hidden border bg-primary-50 border-primary-100 rounded-xl">
+            <div className="p-8">
+              <div className="flex items-center gap-2 mb-4">
+                <div className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary-600">
+                  <svg
+                    className="w-4 h-4 text-white"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253M3 12c0 .778.099 1.533.284 2.253"
+                    />
+                  </svg>
+                </div>
+                <Text className="text-sm font-bold tracking-wide uppercase text-primary-700 max-w-none">
+                  The Purpose
+                </Text>
+              </div>
+              <Text className="leading-relaxed text-gray-700 max-w-none">
+                {data.why}
+              </Text>
+            </div>
+          </div>
+        </div>
+
+        {/* Who It's For — both cards primary */}
+        <div className="mb-12">
+          <Heading level={2}>Who It&apos;s For</Heading>
+          <div className="grid grid-cols-1 gap-4 mt-6 sm:grid-cols-2">
+            {data.benefits.map(benefit => {
+              const Icon = resolveLucideIcon(benefit.icon);
+              return (
+                <div
+                  key={benefit.audience}
+                  className="flex flex-col p-6 border shadow-sm rounded-xl bg-primary-50 border-primary-100"
+                >
+                  <div className="inline-flex items-center justify-center flex-shrink-0 w-10 h-10 mb-4 rounded-lg bg-primary-600">
+                    <Icon className="w-6 h-6 text-white" />
+                  </div>
+                  <Text className="text-xl font-bold max-w-none text-primary-900">
+                    {benefit.audience}
+                  </Text>
+                  <Text className="mt-2 text-sm text-gray-600 max-w-none">
+                    {benefit.description}
+                  </Text>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Get Involved — email and GitHub cards */}
+        <div className="mb-12">
+          <Heading level={2}>Get Involved</Heading>
+          <Text className="mt-2 mb-8 leading-relaxed text-gray-600 max-w-none">
+            BetterGov is open to anyone who believes Filipinos deserve better
+            from their government&apos;s digital services.
+          </Text>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <a
+              href="mailto:volunteers@bettergov.ph"
+              className="flex flex-row items-center gap-5 p-6 text-white transition-colors bg-primary-600 rounded-2xl hover:bg-primary-500"
+            >
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-white/20 shrink-0">
+                <svg
+                  className="w-6 h-6 text-white"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0l-9.75 6.75L2.25 6.75"
+                  />
+                </svg>
+              </div>
+              <div className="text-left">
+                <Text className="font-semibold text-white max-w-none">
+                  Email Us
+                </Text>
+                <Text className="text-xs text-primary-100 max-w-none">
+                  Introduce yourself and tell us how you want to contribute to
+                  the project.
+                </Text>
+              </div>
+            </a>
+
+            <a
+              href="https://github.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex flex-row items-center gap-5 p-6 transition-all bg-white border border-primary-200 rounded-2xl hover:border-primary-400 hover:shadow-md"
+            >
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-primary-50 shrink-0">
+                <svg
+                  className="w-6 h-6 text-primary-600"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12z" />
+                </svg>
+              </div>
+              <div className="text-left">
+                <Text className="font-semibold text-primary-800 max-w-none">
+                  Open an Issue
+                </Text>
+                <Text className="text-xs text-gray-500 max-w-none">
+                  Have an idea or suggestion? Start the conversation on GitHub
+                  and help shape the project.
+                </Text>
+              </div>
+            </a>
+          </div>
+        </div>
+      </Section>
+    </>
+  );
+};
+
+export default AboutBetterGov;

--- a/src/pages/about/BetterGov.tsx
+++ b/src/pages/about/BetterGov.tsx
@@ -55,7 +55,7 @@ const AboutBetterGov: React.FC = () => {
         </div>
       </div>
 
-      <Section className="p-1 px-6 mb-12 sm:px-10 lg:px-20 xl:px-30">
+      <Section className="mb-12 sm:px-10 lg:px-20 xl:px-30">
         {/* Mission — primary blue */}
         <div className="mb-12">
           <Heading level={2}>Our Mission</Heading>

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,0 +1,20 @@
+import { Outlet } from 'react-router-dom';
+import SEO from '../../components/SEO';
+
+const About: React.FC = () => {
+  return (
+    <>
+      <SEO
+        title="About"
+        description="Learn about Allen municipality and the BetterGov initiative."
+        keywords="Allen, municipality, BetterGov, BetterLGU, local government"
+      />
+      <main className="grow">
+        {/* Child route renders here */}
+        <Outlet />
+      </main>
+    </>
+  );
+};
+
+export default About;


### PR DESCRIPTION
Closes #4

## What's changed
- Added `/about`, `/about/allen`, and `/about/bettergov` routes
- About Allen page includes description, key statistics, history timeline, and geography with map
- About BetterGov page includes description, mission, why it was created, who it's for, and get involved section
- Added About section on the homepage with brief cards linking to both subpages
- About entry added to main navigation with dropdown for both subroutes
- All content is driven by YAML files for easy non-technical editing
- SEO metadata added to all About pages

## Notes
- Content for both pages is in `src/data/about_allen.yaml` and `src/data/about_bettergov.yaml`
- Homepage About section pulls directly from the same YAML files