### PR TITLE
feat: added middleware for cf to dynamically add metadata at site req…

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,109 @@
+import metadata from './metadata.json';
+
+interface PageMeta {
+  title: string;
+  description: string;
+}
+
+interface MetadataMap {
+  [path: string]: PageMeta;
+}
+
+const metaMap = metadata as MetadataMap;
+
+function escapeAttr(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export const onRequest = async ({
+  request,
+  next,
+}: {
+  request: Request;
+  next: () => Promise<Response>;
+}) => {
+  const response = await next();
+  const url = new URL(request.url);
+
+  // Only transform HTML responses
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('text/html')) {
+    return response;
+  }
+
+  // Normalize path: strip trailing slash, keep root as /
+  const path = url.pathname.replace(/\/$/, '') || '/';
+
+  // Find metadata — fallback to root if no match
+  const meta = metaMap[path] || metaMap['/'];
+  if (!meta) return response;
+
+  const websiteUrl = `${url.protocol}//${url.host}`;
+  const fullUrl = url.href;
+  const ogImage = `${websiteUrl}/betterallen_navbar_white_text.webp`;
+
+  return new HTMLRewriter()
+    .on('title', {
+      element(el) {
+        el.setInnerContent(meta.title);
+      },
+    })
+    .on('head', {
+      element(el) {
+        el.append(
+          `<meta property="og:title" content="${escapeAttr(meta.title)}" />`,
+          { html: true }
+        );
+        el.append(
+          `<meta property="og:description" content="${escapeAttr(meta.description)}" />`,
+          { html: true }
+        );
+        el.append(
+          `<meta property="og:image" content="${escapeAttr(ogImage)}" />`,
+          { html: true }
+        );
+        el.append(`<meta property="og:image:width" content="1200" />`, {
+          html: true,
+        });
+        el.append(`<meta property="og:image:height" content="630" />`, {
+          html: true,
+        });
+        el.append(
+          `<meta property="og:url" content="${escapeAttr(fullUrl)}" />`,
+          { html: true }
+        );
+        el.append(`<meta property="og:type" content="website" />`, {
+          html: true,
+        });
+        el.append(
+          `<meta property="og:site_name" content="${escapeAttr(meta.title.split('|')[1]?.trim() || '')}" />`,
+          { html: true }
+        );
+        el.append(
+          `<meta name="description" content="${escapeAttr(meta.description)}" />`,
+          { html: true }
+        );
+        el.append(
+          `<meta name="twitter:card" content="summary_large_image" />`,
+          { html: true }
+        );
+        el.append(
+          `<meta name="twitter:title" content="${escapeAttr(meta.title)}" />`,
+          { html: true }
+        );
+        el.append(
+          `<meta name="twitter:description" content="${escapeAttr(meta.description)}" />`,
+          { html: true }
+        );
+        el.append(
+          `<meta name="twitter:image" content="${escapeAttr(ogImage)}" />`,
+          { html: true }
+        );
+      },
+    })
+    .transform(response);
+};

--- a/functions/metadata.json
+++ b/functions/metadata.json
@@ -1,0 +1,518 @@
+{
+  "/": {
+    "title": "Home | Municipality of Allen",
+    "description": "Official website of Municipality of Allen. Discover tourism attractions, government services, and local information for residents and visitors."
+  },
+  "/services": {
+    "title": "Services | Municipality of Allen",
+    "description": "Explore all public services offered by Municipality of Allen. Find what you need for health, business, education, and more."
+  },
+  "/tourism": {
+    "title": "Tourism | Municipality of Allen",
+    "description": "Discover the best tourist spots, accommodations, and attractions in Municipality of Allen."
+  },
+  "/government": {
+    "title": "Government | Municipality of Allen",
+    "description": "Access information on elected leaders, municipal departments, and component barangays of Municipality of Allen."
+  },
+  "/contact": {
+    "title": "Contact Us | Municipality of Allen",
+    "description": "Contact information and emergency hotlines for Municipality of Allen."
+  },
+  "/about": {
+    "title": "About | Municipality of Allen",
+    "description": "Learn about Municipality of Allen and the BetterGov initiative."
+  },
+  "/about/allen": {
+    "title": "About Allen | Municipality of Allen",
+    "description": "Learn about the history, geography, and economy of Municipality of Allen."
+  },
+  "/about/bettergov": {
+    "title": "About BetterGov | Municipality of Allen",
+    "description": "Learn about the BetterGov initiative and how it helps local governments."
+  },
+  "/government/elected-officials": {
+    "title": "Elected Officials | Municipality of Allen",
+    "description": "Meet the elected officials of Municipality of Allen, including the mayor, vice mayor, and councilors."
+  },
+  "/government/elected-officials/committees": {
+    "title": "Municipal Committees | Municipality of Allen",
+    "description": "Active standing committees of the Sangguniang Bayan, including chairpersons and member assignments."
+  },
+  "/government/municipal-offices": {
+    "title": "Municipal Offices | Municipality of Allen",
+    "description": "Directory of municipal offices and departments of Municipality of Allen."
+  },
+  "/government/barangays": {
+    "title": "Barangays | Municipality of Allen",
+    "description": "Browse the component barangays of Municipality of Allen, including officials and contact information."
+  },
+  "/services/health-services": {
+    "title": "Health Services | Municipality of Allen",
+    "description": "Where to go for free check-ups, vaccines, and medicines, which hospitals are available, and details on health programs in your area."
+  },
+  "/services/health-services/get-general-medical-consultation-and-basic-emergency-care": {
+    "title": "Get General Medical Consultation and Basic Emergency Care - Municipality of Allen",
+    "description": "Access outpatient consultation, minor emergency care, and medicine guidance from the Allen RHU."
+  },
+  "/services/health-services/get-dental-checkups-extractions-and-fillings": {
+    "title": "Get Dental Checkups, Extractions, and Fillings - Municipality of Allen",
+    "description": "Avail dental assessment, extraction, filling, and gum care services at the RHU dental clinic."
+  },
+  "/services/health-services/request-a-medical-certificate-for-work-school-or-benefits": {
+    "title": "Request a Medical Certificate for Work, School, or Benefits - Municipality of Allen",
+    "description": "Apply for RHU-issued medical certificates for fit-to-work, school activities, and official requirements."
+  },
+  "/services/health-services/secure-a-sanitary-permit-and-health-card": {
+    "title": "Secure a Sanitary Permit and Health Card - Municipality of Allen",
+    "description": "Complete sanitation inspections and requirements for business permits, health cards, and related certificates."
+  },
+  "/services/health-services/get-free-tb-screening-and-treatment-dots": {
+    "title": "Get Free TB Screening and Treatment (TB-DOTS) - Municipality of Allen",
+    "description": "Receive TB screening, treatment enrollment, and follow-up monitoring under RHU TB-DOTS services."
+  },
+  "/services/health-services/report-notifiable-or-vector-borne-diseases": {
+    "title": "Report Notifiable or Vector-Borne Diseases - Municipality of Allen",
+    "description": "Report infectious or vector-borne disease cases and coordinate with RHU for case management and response."
+  },
+  "/services/health-services/access-family-planning-and-reproductive-health-services": {
+    "title": "Access Family Planning and Reproductive Health Services - Municipality of Allen",
+    "description": "Get counseling and family planning method support for couples and individuals of reproductive age."
+  },
+  "/services/health-services/access-prenatal-and-child-health-services": {
+    "title": "Access Prenatal and Child Health Services - Municipality of Allen",
+    "description": "Use RHU and barangay health station services for prenatal monitoring and child health support."
+  },
+  "/services/health-services/join-nutrition-counseling-and-child-immunization-services": {
+    "title": "Join Nutrition Counseling and Child Immunization Services - Municipality of Allen",
+    "description": "Avail nutrition counseling, malnutrition intervention support, and routine child immunization services."
+  },
+  "/services/health-services/request-an-emergency-ambulance-transfer": {
+    "title": "Request an Emergency Ambulance Transfer - Municipality of Allen",
+    "description": "Coordinate emergency ambulance transfers for eligible referrals and urgent health cases."
+  },
+  "/services/health-services/enroll-in-philhealth-yakap-outpatient-services": {
+    "title": "Enroll in PhilHealth YAKAP Outpatient Services - Municipality of Allen",
+    "description": "Get assisted enrollment and outpatient consultation support under the PhilHealth YAKAP program."
+  },
+  "/services/health-services/get-schistosomiasis-treatment-and-follow-up-care": {
+    "title": "Get Schistosomiasis Treatment and Follow-up Care - Municipality of Allen",
+    "description": "Receive schistosomiasis consultation, medicine access, counseling, and follow-up services."
+  },
+  "/services/health-services/get-leprosy-treatment-and-follow-up-care": {
+    "title": "Get Leprosy Treatment and Follow-up Care - Municipality of Allen",
+    "description": "Access RHU leprosy treatment, counseling, and scheduled monitoring for recovery and continuity of care."
+  },
+  "/services/health-services/get-nutrition-assessment-and-counseling": {
+    "title": "Get Nutrition Assessment and Counseling — Municipality of Allen",
+    "description": "Receive nutrition evaluation and dietary counseling from the Municipal Nutrition Action Office to assess and improve your nutritional status."
+  },
+  "/services/health-services/access-nutrition-program-materials-and-resources": {
+    "title": "Access Nutrition Program Materials and Resources — Municipality of Allen",
+    "description": "Obtain educational materials, supplements, and resources from the Municipal Nutrition Action Office to support your family's nutrition."
+  },
+  "/services/health-services/enroll-in-supplemental-feeding-programs": {
+    "title": "Enroll in Supplemental Feeding Programs — Municipality of Allen",
+    "description": "Register for community and supplemental feeding programs for malnourished children under five, school children, pregnant women, and lactating mothers."
+  },
+  "/services/education": {
+    "title": "Education | Municipality of Allen",
+    "description": "Where to enroll kids in daycare or preschool, how to apply for scholarships, and what education support your LGU offers."
+  },
+  "/services/education/access-early-childhood-education-programs": {
+    "title": "Access Early Childhood Education Programs — Municipality of Allen",
+    "description": "Enroll your child in early childhood education programs offered by the municipal government."
+  },
+  "/services/business": {
+    "title": "Business and Livelihood | Municipality of Allen",
+    "description": "What permits and clearances you need, where to pay taxes or renew permits, and what livelihood or trade opportunities are offered."
+  },
+  "/services/business/secure-a-business-permit": {
+    "title": "Secure a Business Permit — Municipality of Allen",
+    "description": "Apply for a new business permit to legally operate your business in Allen."
+  },
+  "/services/business/renew-your-business-permit": {
+    "title": "Renew Your Business Permit — Municipality of Allen",
+    "description": "Renew your existing business permit to keep your business operation current and compliant."
+  },
+  "/services/business/retire-or-close-a-business-operation": {
+    "title": "Retire or Close a Business Operation — Municipality of Allen",
+    "description": "File for business retirement or closure and obtain the necessary clearances from the Business Permits and Licensing Office."
+  },
+  "/services/business/amend-business-information-and-change-ownership-or-location": {
+    "title": "Amend Business Information and Change Ownership or Location — Municipality of Allen",
+    "description": "Update business details, transfer ownership, or change your business location with the proper amendments."
+  },
+  "/services/business/request-a-certified-true-copy-of-your-business-permit": {
+    "title": "Request a Certified True Copy of Your Business Permit — Municipality of Allen",
+    "description": "Obtain certified copies of your business permit for official use or documentation purposes."
+  },
+  "/services/business/get-a-certification-of-no-business-record": {
+    "title": "Get a Certification of No Business Record — Municipality of Allen",
+    "description": "Receive an official certification stating that you have no existing business records in the municipality."
+  },
+  "/services/business/secure-an-occupational-permit": {
+    "title": "Secure an Occupational Permit — Municipality of Allen",
+    "description": "Apply for an occupational permit for professionals and special trades requiring this license."
+  },
+  "/services/social-welfare": {
+    "title": "Social Welfare | Municipality of Allen",
+    "description": "What assistance is available for seniors, PWDs, solo parents, and indigent families, plus details on relief goods, and livelihood aid."
+  },
+  "/services/social-welfare/get-a-person-with-disability-pwd-identification-card": {
+    "title": "Get a Person with Disability (PWD) Identification Card — Municipality of Allen",
+    "description": "Apply for an official PWD ID card to access services and privileges for persons with disabilities."
+  },
+  "/services/social-welfare/get-a-senior-citizen-identification-card": {
+    "title": "Get a Senior Citizen Identification Card — Municipality of Allen",
+    "description": "Obtain a senior citizen ID to enjoy discounts, benefits, and privileges available to seniors."
+  },
+  "/services/social-welfare/get-pre-marriage-counseling": {
+    "title": "Get Pre-Marriage Counseling — Municipality of Allen",
+    "description": "Participate in pre-marriage counseling programs to prepare for married life."
+  },
+  "/services/social-welfare/access-welfare-programs-for-socially-disadvantaged-women": {
+    "title": "Access Welfare Programs for Socially Disadvantaged Women — Municipality of Allen",
+    "description": "Learn about and access welfare and support programs designed for socially disadvantaged women."
+  },
+  "/services/social-welfare/get-a-solo-parent-identification-card": {
+    "title": "Get a Solo Parent Identification Card — Municipality of Allen",
+    "description": "Obtain an official solo parent ID to qualify for support programs and government assistance."
+  },
+  "/services/social-welfare/access-intervention-and-diversion-programs-for-children-in-conflict-with-the-law": {
+    "title": "Access Intervention and Diversion Programs for Children in Conflict with the Law — Municipality of Allen",
+    "description": "Access rehabilitation and diversion programs for children in conflict with the law (CICL)."
+  },
+  "/services/social-welfare/get-care-and-protection-for-children-in-need-of-special-assistance": {
+    "title": "Get Care and Protection for Children in Need of Special Assistance — Municipality of Allen",
+    "description": "Access care and protection services for children who are at risk or need special assistance."
+  },
+  "/services/social-welfare/apply-for-financial-assistance-during-crisis-situations": {
+    "title": "Apply for Financial Assistance During Crisis Situations — Municipality of Allen",
+    "description": "Receive financial assistance and support if you are facing an individual crisis or emergency."
+  },
+  "/services/social-welfare/get-a-certificate-of-indigency-or-financial-assessment": {
+    "title": "Get a Certificate of Indigency or Financial Assessment — Municipality of Allen",
+    "description": "Obtain an official certificate of indigency or financial assessment for various official purposes."
+  },
+  "/services/social-welfare/request-a-social-case-study-report": {
+    "title": "Request a Social Case Study Report — Municipality of Allen",
+    "description": "Apply for a social case study report from the Social Welfare Office for official documentation."
+  },
+  "/services/social-welfare/get-referral-letters-to-partner-agencies": {
+    "title": "Get Referral Letters to Partner Agencies — Municipality of Allen",
+    "description": "Receive referral letters to access services from other government agencies and partner organizations."
+  },
+  "/services/agriculture-fisheries": {
+    "title": "Agriculture & Fisheries | Municipality of Allen",
+    "description": "What farm or fishing support is available, including seeds, fertilizers, veterinary care, and where to join training or borrow equipment."
+  },
+  "/services/agriculture-fisheries/get-technical-assistance-on-crop-production-and-management": {
+    "title": "Get Technical Assistance on Crop Production and Management — Municipality of Allen",
+    "description": "Access free technical assistance and guidance on crop production, management, and farming best practices."
+  },
+  "/services/agriculture-fisheries/enroll-in-the-registry-system-for-basic-sector-in-agriculture": {
+    "title": "Enroll in the Registry System for Basic Sector in Agriculture (RSBSA) — Municipality of Allen",
+    "description": "Register in the RSBSA to get access to agricultural programs, benefits, and services from the government."
+  },
+  "/services/agriculture-fisheries/get-free-insurance-for-crops-livestock-and-fisheries": {
+    "title": "Get Free Insurance for Crops, Livestock, and Fisheries — Municipality of Allen",
+    "description": "Apply for free government insurance coverage for your crops, livestock, and fishing operations."
+  },
+  "/services/agriculture-fisheries/access-free-inbred-and-hybrid-seeds-through-rcef": {
+    "title": "Access Free Inbred and Hybrid Seeds Through RCEF — Municipality of Allen",
+    "description": "Receive free inbred and hybrid seeds from the Rural Credit and Guarantee Corporation (RCEF) program."
+  },
+  "/services/agriculture-fisheries/get-free-vegetable-seeds-for-backyard-gardening": {
+    "title": "Get Free Vegetable Seeds for Backyard Gardening — Municipality of Allen",
+    "description": "Request free vegetable seeds to start and maintain a backyard garden for your household."
+  },
+  "/services/agriculture-fisheries/access-support-services-from-da-bfar-and-partner-agencies": {
+    "title": "Access Support Services from DA, BFAR, and Partner Agencies — Municipality of Allen",
+    "description": "Get referrals and support services from the Department of Agriculture, BFAR, and other partner agencies."
+  },
+  "/services/agriculture-fisheries/get-veterinary-services-for-your-farm-animals": {
+    "title": "Get Veterinary Services for Your Farm Animals — Municipality of Allen",
+    "description": "Avail of free or subsidized veterinary services for livestock, poultry, and other farm animals."
+  },
+  "/services/infrastructure-public-works": {
+    "title": "Infrastructure & Public Works | Municipality of Allen",
+    "description": "How to report damaged roads or drainage, where to request water supply, and how to access public facilities and markets."
+  },
+  "/services/infrastructure-public-works/get-an-electrical-and-building-permit-or-occupancy-permit": {
+    "title": "Get an Electrical and Building Permit or Occupancy Permit — Municipality of Allen",
+    "description": "Apply for an electrical and building permit or occupancy permit for construction and structural projects."
+  },
+  "/services/infrastructure-public-works/get-an-electrical-permit": {
+    "title": "Get an Electrical Permit — Municipality of Allen",
+    "description": "Obtain an electrical permit for electrical installation and wiring work on your property."
+  },
+  "/services/infrastructure-public-works/request-a-program-of-work": {
+    "title": "Request a Program of Work — Municipality of Allen",
+    "description": "Get the preparation and issuance of a program of work for your construction or development project."
+  },
+  "/services/garbage-waste-disposal": {
+    "title": "Garbage and Waste Disposal | Municipality of Allen",
+    "description": "Garbage collection schedules, waste disposal guidelines, and how to properly dispose of different types of waste."
+  },
+  "/services/garbage-waste-disposal/garbage-collection-services": {
+    "title": "Secure Garbage Collection Services — Municipality of Allen",
+    "description": "Timely collection of segregated waste for residential, commercial, and institutional properties."
+  },
+  "/services/garbage-waste-disposal/garbage-collection-special-trip": {
+    "title": "Request Special Garbage Collection — Municipality of Allen",
+    "description": "On-demand garbage collection service for special situations requiring additional trips."
+  },
+  "/services/environment": {
+    "title": "Environment | Municipality of Allen",
+    "description": "Clean-up or tree planting activities, environmental protection rules, and conservation programs."
+  },
+  "/services/disaster-preparedness": {
+    "title": "Disaster Preparedness | Municipality of Allen",
+    "description": "Disaster preparedness plans, emergency response information, and evacuation procedures."
+  },
+  "/services/disaster-preparedness/attend-disaster-preparedness-lectures": {
+    "title": "Attend Disaster Preparedness Lectures — Municipality of Allen",
+    "description": "Participate in disaster preparedness and awareness lectures offered by the municipal government."
+  },
+  "/services/disaster-preparedness/request-simulation-exercises-and-drills": {
+    "title": "Request Simulation Exercises and Drills — Municipality of Allen",
+    "description": "Request the conduct of disaster simulation exercises and drills for your organization or barangay."
+  },
+  "/services/disaster-preparedness/request-emergency-response-team-assistance": {
+    "title": "Request Emergency Response Team Assistance — Municipality of Allen",
+    "description": "Contact the emergency response team for assistance during disasters, accidents, or emergency situations."
+  },
+  "/services/housing-land-use": {
+    "title": "Housing & Land Use | Municipality of Allen",
+    "description": "How to apply for housing projects, what zoning and building permits are needed, and where relocation sites are available."
+  },
+  "/services/civil-registry": {
+    "title": "Civil Registry | Municipality of Allen",
+    "description": "How to register births, marriages, deaths, and other vital records, and how to request certificates and documents from the Civil Registrar."
+  },
+  "/services/civil-registry/register-a-birth-death-or-marriage-document-late": {
+    "title": "Register a Birth, Death, or Marriage Document Late — Municipality of Allen",
+    "description": "File a late registration of civil registry documents (birth, death, or marriage certificates) with the Civil Registrar."
+  },
+  "/services/civil-registry/register-a-birth-death-or-marriage-document-on-time": {
+    "title": "Register a Birth, Death, or Marriage Document on Time — Municipality of Allen",
+    "description": "Complete timely registration of civil registry documents for births, deaths, and marriages with required documentation."
+  },
+  "/services/civil-registry/get-a-certificate-or-transcription-of-birth-death-or-marriage": {
+    "title": "Get a Certificate or Transcription of Birth, Death, or Marriage — Municipality of Allen",
+    "description": "Request and obtain a certified certificate or transcription of birth, death, or marriage records from the Civil Registrar."
+  },
+  "/services/civil-registry/file-for-correction-of-clerical-error-change-of-name-or-change-of-gender": {
+    "title": "File for Correction of Clerical Error, Change of Name, or Change of Gender — Municipality of Allen",
+    "description": "File a petition for correction of clerical errors (CCE), change of first name (CFN), or change of gender/sex in civil registry records."
+  },
+  "/services/civil-registry/process-legal-instruments-through-the-civil-registrar": {
+    "title": "Process Legal Instruments Through the Civil Registrar — Municipality of Allen",
+    "description": "Submit legal instruments for processing and registration with the Civil Registrar office."
+  },
+  "/services/civil-registry/register-a-court-decree": {
+    "title": "Register a Court Decree — Municipality of Allen",
+    "description": "File and register court decrees related to civil status with the Civil Registrar."
+  },
+  "/services/civil-registry/get-a-certified-photocopy-or-certification-of-registration-documents": {
+    "title": "Get a Certified Photocopy or Certification of Registration Documents — Municipality of Allen",
+    "description": "Request certified photocopies or certification of any civil registration documents from the Civil Registrar."
+  },
+  "/services/tax-revenue": {
+    "title": "Tax & Revenue | Municipality of Allen",
+    "description": "Where to pay taxes and fees, how to inquire about property assessments, and information about business taxes and revenue services."
+  },
+  "/services/tax-revenue/get-a-community-tax-certificate": {
+    "title": "Get a Community Tax Certificate — Municipality of Allen",
+    "description": "Apply for and obtain a community tax certificate from the Treasurer's Office."
+  },
+  "/services/tax-revenue/get-an-official-receipt-for-civil-registry-matters": {
+    "title": "Get an Official Receipt for Civil Registry Matters — Municipality of Allen",
+    "description": "Receive official receipts for payments related to civil registry documents and transactions."
+  },
+  "/services/tax-revenue/pay-your-real-property-tax": {
+    "title": "Pay Your Real Property Tax — Municipality of Allen",
+    "description": "Make payments for real property taxes at the Treasurer's Office."
+  },
+  "/services/tax-revenue/get-a-tax-clearance-or-certificate": {
+    "title": "Get a Tax Clearance or Certificate — Municipality of Allen",
+    "description": "Request a tax clearance certificate or tax payment certificate from the Treasurer's Office."
+  },
+  "/services/tax-revenue/get-a-tax-bill-or-letter-of-delinquency": {
+    "title": "Get a Tax Bill or Letter of Delinquency — Municipality of Allen",
+    "description": "Request the preparation and issuance of tax bills and letters of delinquency for unpaid taxes."
+  },
+  "/services/tax-revenue/get-receipts-for-police-clearance-livestock-registration-and-other-fees": {
+    "title": "Get Receipts for Police Clearance, Livestock Registration, and Other Fees — Municipality of Allen",
+    "description": "Obtain official receipts for police clearance fees, large cattle registration, and other municipal fees."
+  },
+  "/services/tax-revenue/pay-your-mayors-business-permit": {
+    "title": "Pay Your Mayor's Business Permit — Municipality of Allen",
+    "description": "Make payments for mayor's business permit fees at the Treasurer's Office."
+  },
+  "/services/tax-revenue/pay-market-stall-rental-or-cemetery-lot-lease": {
+    "title": "Pay Market Stall Rental or Cemetery Lot Lease — Municipality of Allen",
+    "description": "Pay fees for market space rental, lease of market stalls, and public cemetery lot leases."
+  },
+  "/services/tax-revenue/process-payroll-and-voucher-payments": {
+    "title": "Process Payroll and Voucher Payments — Municipality of Allen",
+    "description": "Request fund disbursement, payment of payrolls, and processing of vouchers from the Treasurer's Office."
+  },
+  "/services/tax-revenue/get-a-certified-copy-of-your-tax-declaration": {
+    "title": "Get a Certified Copy of Your Tax Declaration — Municipality of Allen",
+    "description": "Request certified true copies or photocopies of your tax declaration from the Assessor's Office."
+  },
+  "/services/tax-revenue/transfer-property-ownership-or-tax-declaration": {
+    "title": "Transfer Property Ownership or Tax Declaration — Municipality of Allen",
+    "description": "File for transfer of ownership or update your tax declaration with the Assessor's Office."
+  },
+  "/services/tax-revenue/request-lot-subdivision-or-consolidation": {
+    "title": "Request Lot Subdivision or Consolidation — Municipality of Allen",
+    "description": "File for subdivision or consolidation of land lots at the Assessor's Office."
+  },
+  "/services/tax-revenue/apply-for-land-conversion": {
+    "title": "Apply for Land Conversion — Municipality of Allen",
+    "description": "Submit an application for land conversion with the Assessor's Office."
+  },
+  "/services/tax-revenue/request-property-reclassification": {
+    "title": "Request Property Reclassification — Municipality of Allen",
+    "description": "File for re-classification of your property with the Assessor's Office."
+  },
+  "/services/tax-revenue/get-a-property-certification-from-the-assessor": {
+    "title": "Get a Property Certification from the Assessor — Municipality of Allen",
+    "description": "Request certifications and official documents from the Assessor's Office regarding your property."
+  },
+  "/services/employment": {
+    "title": "Employment & Jobs | Municipality of Allen",
+    "description": "Job placement assistance, career counseling, employment programs, and local hiring opportunities from PESO and HRMO services."
+  },
+  "/services/employment/access-tupad-assistance-for-displaced-workers": {
+    "title": "Access TUPAD Assistance for Displaced Workers — Municipality of Allen",
+    "description": "Apply for Tulong Panghanapbuhay sa Ating Displaced/Disadvantage Workers (TUPAD) program for employment assistance."
+  },
+  "/services/employment/apply-for-the-government-internship-program": {
+    "title": "Apply for the Government Internship Program — Municipality of Allen",
+    "description": "Apply for the Government Internship Program (GIP) to gain work experience in local government."
+  },
+  "/services/employment/apply-for-the-special-program-for-employment-of-students": {
+    "title": "Apply for the Special Program for Employment of Students — Municipality of Allen",
+    "description": "Participate in the Special Program for Employment and Students (SPES) to work while studying."
+  },
+  "/services/employment/get-an-applicant-referral-letter-for-employment": {
+    "title": "Get an Applicant Referral Letter for Employment — Municipality of Allen",
+    "description": "Request a referral letter or application for employment from the Public Employment Service Office."
+  },
+  "/services/employment/apply-for-company-accreditation": {
+    "title": "Apply for Company Accreditation — Municipality of Allen",
+    "description": "Submit an application for company accreditation with the Public Employment Service Office."
+  },
+  "/services/employment/apply-for-recruitment-activity-approval": {
+    "title": "Apply for Recruitment Activity Approval — Municipality of Allen",
+    "description": "Request approval to conduct recruitment activities for local and overseas employment."
+  },
+  "/services/employment/request-a-job-posting": {
+    "title": "Request a Job Posting — Municipality of Allen",
+    "description": "Submit your job vacancies for posting at the Public Employment Service Office."
+  },
+  "/services/employment/get-employment-and-career-coaching": {
+    "title": "Get Employment and Career Coaching — Municipality of Allen",
+    "description": "Access coaching and guidance services for employment and career development from PESO."
+  },
+  "/services/employment/access-dilp-livelihood-assistance": {
+    "title": "Access DILP Livelihood Assistance — Municipality of Allen",
+    "description": "Apply for the DOLE Integrated Livelihood Program (DILP) for livelihood and skills training."
+  },
+  "/services/employment/get-assistance-from-the-owwa-help-desk": {
+    "title": "Get Assistance from the OWWA Help Desk — Municipality of Allen",
+    "description": "Access services and assistance from the Overseas Workers Welfare Administration (OWWA) Help Desk."
+  },
+  "/services/employment/submit-a-job-application": {
+    "title": "Submit a Job Application — Municipality of Allen",
+    "description": "Submit your job application to the Human Resource Management Office."
+  },
+  "/services/employment/submit-documents-or-correspondence": {
+    "title": "Submit Documents or Correspondence — Municipality of Allen",
+    "description": "Submit documents, forms, or correspondence to the Human Resource Management Office."
+  },
+  "/services/employment/request-employment-verification": {
+    "title": "Request Employment Verification — Municipality of Allen",
+    "description": "Request verification of your employment status from the Human Resource Management Office."
+  },
+  "/services/employment/apply-for-leave": {
+    "title": "Apply for Leave — Municipality of Allen",
+    "description": "Submit a leave application to the Human Resource Management Office."
+  },
+  "/services/employment/get-a-certificate-of-employment": {
+    "title": "Get a Certificate of Employment — Municipality of Allen",
+    "description": "Request a certificate of employment from the Human Resource Management Office."
+  },
+  "/services/employment/get-your-service-record": {
+    "title": "Get Your Service Record — Municipality of Allen",
+    "description": "Obtain your service record from the Human Resource Management Office."
+  },
+  "/services/employment/get-a-contract-of-service-or-job-contract": {
+    "title": "Get a Contract of Service or Job Order Contract — Municipality of Allen",
+    "description": "Request the preparation and issuance of a contract of service or job contract from HRMO."
+  },
+  "/services/employment/get-a-certification-of-earned-leave-credits": {
+    "title": "Get a Certification of Earned Leave Credits — Municipality of Allen",
+    "description": "Request a certification of your earned leave credits from the Human Resource Management Office."
+  },
+  "/services/tourism": {
+    "title": "Tourism & Culture | Municipality of Allen",
+    "description": "Tourist information, cultural events, heritage sites, and how to access tourism and cultural development programs."
+  },
+  "/services/tourism/get-tourist-information-services": {
+    "title": "Get Tourist Information Services — Municipality of Allen",
+    "description": "Access information about tourist attractions, accommodations, events, and travel services in Allen."
+  },
+  "/services/tourism/request-tourism-data": {
+    "title": "Request Tourism Data — Municipality of Allen",
+    "description": "Submit a request for tourism-related data and statistics from the Tourism Office."
+  },
+  "/services/tourism/apply-for-dot-accreditation-as-a-tourism-enterprise": {
+    "title": "Apply for DOT Accreditation as a Tourism Enterprise — Municipality of Allen",
+    "description": "Apply for Department of Tourism (DOT) accreditation of your tourism business or enterprise."
+  },
+  "/services/tourism/get-tourism-related-certifications": {
+    "title": "Get Tourism-Related Certifications — Municipality of Allen",
+    "description": "Request the issuance of tourism-related certifications and compliance documents from the Tourism Office."
+  },
+  "/services/tourism/file-a-tourism-related-complaint": {
+    "title": "File a Tourism-Related Complaint — Municipality of Allen",
+    "description": "Report and file complaints related to tourism services and tourist experiences in Allen."
+  },
+  "/services/legislative": {
+    "title": "Legislative | Municipality of Allen",
+    "description": "Information about ordinances, permits, consultations with the Sangguniang Bayan, and other legislative and governance services."
+  },
+  "/services/legislative/submit-an-ordinance-or-resolution-for-approval": {
+    "title": "Submit an Ordinance or Resolution for Approval — Municipality of Allen",
+    "description": "Submit proposed ordinances and resolutions to the Sangguniang Bayan for review and approval."
+  },
+  "/tourism/beaches-resorts": {
+    "title": "Beaches and Resorts | Municipality of Allen",
+    "description": "Discover the pristine beaches and luxury resorts that make Allen a coastal paradise."
+  },
+  "/tourism/cafes-dining": {
+    "title": "Cafes and Dining | Municipality of Allen",
+    "description": "Explore local cafes, restaurants, and dining spots offering delicious local and international cuisine."
+  },
+  "/tourism/hotels-lodging": {
+    "title": "Hotels and Lodging | Municipality of Allen",
+    "description": "Find comfortable accommodations ranging from budget-friendly inns to luxury hotels."
+  },
+  "/tourism/nature-outdoor": {
+    "title": "Nature and Outdoor Spots | Municipality of Allen",
+    "description": "Experience the natural beauty of Allen through its parks, mountains, and outdoor attractions."
+  },
+  "/tourism/cultural-heritage": {
+    "title": "Cultural and Heritage Sites | Municipality of Allen",
+    "description": "Visit historical landmarks and cultural sites that showcase Allen's rich heritage."
+  },
+  "/tourism/activities-recreation": {
+    "title": "Activities and Recreation | Municipality of Allen",
+    "description": "Enjoy various recreational activities and entertainment options available in Allen."
+  }
+}

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types"],
+    "resolveJsonModule": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/index.html
+++ b/index.html
@@ -4,13 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>
-      BetterGov.ph | Republic of the Philippines | Community Powered Government
-      Portal
-    </title>
+    <title>Municipality of Allen - Official Government Website</title>
     <meta
       name="description"
-      content="Community-powered portal of the Republic of the Philippines. Access government services, stay updated with the latest news, and find information about the Philippines."
+      content="Official website of the Municipality of Allen. Access government services, tourism information, and local resources for residents and visitors."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260508.1",
         "@eslint/js": "^9.35.0",
         "@tailwindcss/vite": "^4.0.0",
         "@types/node": "^24.5.2",
@@ -551,6 +552,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260508.1.tgz",
+      "integrity": "sha512-0KNR+UkrYJYmtyQ5tOjUT/wt/U34FuE4Y8FLSbPMwFrGQQpmvR9wKghwRkL4d28y5t9jI9cvGqeAoo/cerTnCQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.62.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "dev:host": "vite --host",
-    "build": "npm run generate-sitemap && tsc -b && vite build",
+    "build": "npm run generate-og-manifest && npm run generate-sitemap && tsc -b && vite build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -16,7 +16,8 @@
     "convert-yaml": "node scripts/yaml-to-json.js",
     "dev:yaml": "npm run convert-yaml && npm run dev",
     "setup": "node scripts/setup-starter-kit.js",
-    "generate-sitemap": "node scripts/generate-sitemap.js"
+    "generate-sitemap": "node scripts/generate-sitemap.js",
+    "generate-og-manifest": "node scripts/generate-og-manifest.js"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
@@ -61,6 +62,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260508.1",
     "@eslint/js": "^9.35.0",
     "@tailwindcss/vite": "^4.0.0",
     "@types/node": "^24.5.2",

--- a/scripts/generate-og-manifest.js
+++ b/scripts/generate-og-manifest.js
@@ -1,0 +1,224 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import yaml from 'js-yaml';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const SITE_NAME = process.env.VITE_GOVERNMENT_NAME || 'Municipality of Allen';
+const OG_IMAGE = '/betterallen_navbar_white_text.webp';
+
+function readYaml(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return yaml.load(raw);
+  } catch {
+    return null;
+  }
+}
+
+function readText(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function extractTitleAndDescription(markdown) {
+  const titleMatch = markdown.match(/^#\s+(.+)$/m);
+  const title = titleMatch ? titleMatch[1].trim() : undefined;
+  const descMatch = markdown.match(/^#\s+.+$\n\n(.+?)(?:\n\n|$)/s);
+  const description = descMatch
+    ? descMatch[1].replace(/^>\s*/, '').trim()
+    : undefined;
+  return { title, description };
+}
+
+const manifest = {};
+
+// ── Static routes ──
+const staticRoutes = {
+  '/': {
+    title: `Home | ${SITE_NAME}`,
+    description: `Official website of ${SITE_NAME}. Discover tourism attractions, government services, and local information for residents and visitors.`,
+  },
+  '/services': {
+    title: `Services | ${SITE_NAME}`,
+    description: `Explore all public services offered by ${SITE_NAME}. Find what you need for health, business, education, and more.`,
+  },
+  '/tourism': {
+    title: `Tourism | ${SITE_NAME}`,
+    description: `Discover the best tourist spots, accommodations, and attractions in ${SITE_NAME}.`,
+  },
+  '/government': {
+    title: `Government | ${SITE_NAME}`,
+    description: `Access information on elected leaders, municipal departments, and component barangays of ${SITE_NAME}.`,
+  },
+  '/contact': {
+    title: `Contact Us | ${SITE_NAME}`,
+    description: `Contact information and emergency hotlines for ${SITE_NAME}.`,
+  },
+  '/about': {
+    title: `About | ${SITE_NAME}`,
+    description: `Learn about ${SITE_NAME} and the BetterGov initiative.`,
+  },
+  '/about/allen': {
+    title: `About Allen | ${SITE_NAME}`,
+    description: `Learn about the history, geography, and economy of ${SITE_NAME}.`,
+  },
+  '/about/bettergov': {
+    title: `About BetterGov | ${SITE_NAME}`,
+    description: `Learn about the BetterGov initiative and how it helps local governments.`,
+  },
+  '/government/elected-officials': {
+    title: `Elected Officials | ${SITE_NAME}`,
+    description: `Meet the elected officials of ${SITE_NAME}, including the mayor, vice mayor, and councilors.`,
+  },
+  '/government/elected-officials/committees': {
+    title: `Municipal Committees | ${SITE_NAME}`,
+    description: `Active standing committees of the Sangguniang Bayan, including chairpersons and member assignments.`,
+  },
+  '/government/municipal-offices': {
+    title: `Municipal Offices | ${SITE_NAME}`,
+    description: `Directory of municipal offices and departments of ${SITE_NAME}.`,
+  },
+  '/government/barangays': {
+    title: `Barangays | ${SITE_NAME}`,
+    description: `Browse the component barangays of ${SITE_NAME}, including officials and contact information.`,
+  },
+};
+
+Object.assign(manifest, staticRoutes);
+
+// ── Service categories ──
+const servicesFile = path.join(root, 'src/data/services.yaml');
+const servicesData = readYaml(servicesFile);
+if (servicesData?.categories) {
+  for (const cat of servicesData.categories) {
+    const catPath = `/services/${cat.slug}`;
+    manifest[catPath] = {
+      title: `${cat.category} | ${SITE_NAME}`,
+      description:
+        cat.description ||
+        `Explore ${cat.category} services offered by ${SITE_NAME}.`,
+    };
+
+    // Service documents
+    const indexFile = path.join(
+      root,
+      'content/services',
+      cat.slug,
+      'index.yaml'
+    );
+    const indexData = readYaml(indexFile);
+    if (indexData?.pages) {
+      for (const page of indexData.pages) {
+        const pagePath = `${catPath}/${page.slug}`;
+        // Try markdown for better description
+        const mdFile = path.join(
+          root,
+          'content/services',
+          cat.slug,
+          `${page.slug}.md`
+        );
+        const mdContent = readText(mdFile);
+        if (mdContent) {
+          const { title, description } = extractTitleAndDescription(mdContent);
+          manifest[pagePath] = {
+            title: title || `${page.name} | ${SITE_NAME}`,
+            description:
+              description ||
+              page.description ||
+              `${page.name} — a service offered by ${SITE_NAME}.`,
+          };
+        } else {
+          manifest[pagePath] = {
+            title: `${page.name} | ${SITE_NAME}`,
+            description:
+              page.description ||
+              `${page.name} — a service offered by ${SITE_NAME}.`,
+          };
+        }
+      }
+    }
+  }
+}
+
+// ── Government document pages (markdown) ──
+const govFile = path.join(root, 'src/data/government.yaml');
+const govData = readYaml(govFile);
+if (govData?.categories) {
+  for (const cat of govData.categories) {
+    const indexFile = path.join(
+      root,
+      'content/government',
+      cat.slug,
+      'index.yaml'
+    );
+    const indexData = readYaml(indexFile);
+    if (indexData?.pages) {
+      for (const page of indexData.pages) {
+        const pagePath = `/government/${cat.slug}/${page.slug}`;
+        const mdFile = path.join(
+          root,
+          'content/government',
+          cat.slug,
+          `${page.slug}.md`
+        );
+        const mdContent = readText(mdFile);
+        if (mdContent) {
+          const { title, description } = extractTitleAndDescription(mdContent);
+          manifest[pagePath] = {
+            title: title || `${page.name} | ${SITE_NAME}`,
+            description:
+              description ||
+              page.description ||
+              `${page.name} — ${cat.category} information from ${SITE_NAME}.`,
+          };
+        }
+      }
+    }
+  }
+}
+
+// ── Tourism categories ──
+const tourismFile = path.join(root, 'src/data/tourism.yaml');
+const tourismData = readYaml(tourismFile);
+if (tourismData?.categories) {
+  for (const cat of tourismData.categories) {
+    const catPath = `/tourism/${cat.slug}`;
+    manifest[catPath] = {
+      title: `${cat.category} | ${SITE_NAME}`,
+      description:
+        cat.description || `Explore ${cat.category} in ${SITE_NAME}.`,
+    };
+
+    // Tourism places
+    const indexFile = path.join(
+      root,
+      'content/tourism',
+      cat.slug,
+      'index.yaml'
+    );
+    const indexData = readYaml(indexFile);
+    if (indexData?.places) {
+      for (const place of indexData.places) {
+        // Places don't have individual pages yet, but we include them in
+        // the category page metadata. Individual place routes can be added
+        // here when they get their own pages.
+      }
+    }
+  }
+}
+
+// ── Write manifest ──
+const outDir = path.join(root, 'functions');
+if (!fs.existsSync(outDir)) {
+  fs.mkdirSync(outDir, { recursive: true });
+}
+const outFile = path.join(outDir, 'metadata.json');
+fs.writeFileSync(outFile, JSON.stringify(manifest, null, 2), 'utf8');
+console.log(`✓ OG manifest generated at ${outFile}`);
+console.log(`  ${Object.keys(manifest).length} routes registered`);

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -30,11 +30,12 @@ export default function SEO({
   const fullTitle = title ? `${title} | ${siteName}` : defaultTitle;
   const fullDescription = description || defaultDescription;
   const fullKeywords = keywords || defaultKeywords;
-  const fullUrl = url || import.meta.env.VITE_WEBSITE_URL || '';
+  const fullUrl =
+    url || window.location.href || import.meta.env.VITE_WEBSITE_URL || '';
   const fullImage =
     image ||
     import.meta.env.VITE_OG_IMAGE_URL ||
-    `${fullUrl}/betterallen_navbar.png`;
+    `${fullUrl}/betterallen_navbar.webp`;
   const twitterHandle = import.meta.env.VITE_TWITTER_HANDLE || '';
 
   return (

--- a/src/data/government.yaml
+++ b/src/data/government.yaml
@@ -2,7 +2,7 @@
 # This file contains all the local government activity data for the local government portal
 # Non-technical users can easily edit this file to add, remove, or modify local government activity
 
-categories: 
+categories:
   - category: 'Elected Officials'
     slug: 'elected-officials'
     description: 'Meet your local elected officials, including the mayor, vice mayor, and councilors, with their profiles, contact information, and term details.'

--- a/src/pages/Tourism.tsx
+++ b/src/pages/Tourism.tsx
@@ -4,8 +4,9 @@ import { Heading } from '../components/ui/Heading';
 import { Text } from '../components/ui/Text';
 import {
   tourismCategories,
-  getTourismPlaces,
   getFeaturedPlaces,
+  getTourismPlaces,
+  isTourismCategory,
 } from '../data/tourismLoader';
 import Breadcrumbs from '../components/ui/Breadcrumbs';
 import SEO from '../components/SEO';
@@ -13,7 +14,6 @@ import { Card, CardContent } from '@bettergov/kapwa/card';
 import { Banner } from '@bettergov/kapwa/banner';
 import { useState, useEffect } from 'react';
 import { resolveLucideIcon } from '../lib/utils';
-import TourismCard from '@/components/ui/TourismCard';
 import { MapPin } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { FiFacebook } from 'react-icons/fi';
@@ -32,16 +32,6 @@ const Tourism: React.FC = () => {
     );
     return () => clearInterval(id);
   }, []);
-
-  const getCategory = () => {
-    return tourismCategories.categories.find(c => c.slug === category);
-  };
-
-  const categoryData = getCategory();
-  const Icon = resolveLucideIcon(categoryData?.icon);
-
-  const places = category && categoryData ? getTourismPlaces(category) : [];
-
   if (!category) {
     return (
       <>
@@ -167,7 +157,11 @@ const Tourism: React.FC = () => {
     );
   }
 
-  if (!categoryData) {
+  const categoryData = tourismCategories.categories.find(
+    c => c.slug === category
+  );
+
+  if (!categoryData || !isTourismCategory(category)) {
     return (
       <Section className="p-3 mb-12">
         <Breadcrumbs
@@ -188,47 +182,73 @@ const Tourism: React.FC = () => {
     );
   }
 
+  const places = getTourismPlaces(category);
+  const CatIcon = resolveLucideIcon(categoryData.icon);
+
   return (
     <>
       <SEO
-        title={`${categoryData.category} | Tourism`}
+        title={categoryData.category}
         description={categoryData.description}
-        keywords={`${categoryData.category}, tourism, travel, attractions, ${import.meta.env.VITE_GOVERNMENT_NAME}`}
+        keywords={`${categoryData.category}, tourism, travel, ${import.meta.env.VITE_GOVERNMENT_NAME}`}
       />
-      <Section className="p-3 mb-12" maxWidth="full">
+      <Section
+        className="p-3 mb-12"
+        aria-label={`${categoryData.category} places`}
+      >
         <Breadcrumbs
           items={[
             { label: 'Home', href: '/' },
             { label: 'Tourism', href: '/tourism' },
             { label: categoryData.category },
           ]}
-          lightBg={true}
           className="mb-8"
         />
-        <Icon className="h-8 w-8 mb-4 text-primary-600 rounded-md" />
-        <Heading level={3}>{categoryData.category}</Heading>
+        <div
+          className={`${categoryData.color.bg} ${categoryData.color.text} p-3 rounded-md mb-4 w-fit`}
+          aria-hidden="true"
+        >
+          <CatIcon className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <Heading>{categoryData.category}</Heading>
         <Text className="text-gray-600 mb-6">{categoryData.description}</Text>
 
         {places.length === 0 ? (
           <Text className="text-gray-500 text-center py-8">
-            No places listed for this category yet.
+            No places available in this category at the moment.
           </Text>
         ) : (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {places.map(place => (
-              <TourismCard
+              <Card
                 key={place.slug}
-                name={place.name}
-                description={place.description}
-                slug={place.slug}
-                barangay={place.barangay}
-                category={place.category}
-                categoryColor={place.categoryColor}
-                image={place.image}
-                mapsUrl={place.mapsUrl}
-                contact={place.contact}
-                socialUrl={place.socialUrl}
-              />
+                hoverable
+                className={`h-full border-t-4 ${categoryData.color.border}`}
+              >
+                <CardContent>
+                  {place.image && (
+                    <div
+                      className="h-40 bg-cover bg-center rounded-md mb-4"
+                      style={{ backgroundImage: `url(${place.image})` }}
+                      aria-hidden="true"
+                    />
+                  )}
+                  <Heading
+                    level={5}
+                    className="font-semibold text-gray-900 mb-2"
+                  >
+                    {place.name}
+                  </Heading>
+                  <Text className="text-sm text-gray-600 mb-2">
+                    {place.description}
+                  </Text>
+                  {place.barangay && (
+                    <span className="inline-block px-2 py-1 text-xs font-medium rounded-sm bg-gray-100 text-gray-800">
+                      {place.barangay}
+                    </span>
+                  )}
+                </CardContent>
+              </Card>
             ))}
           </div>
         )}

--- a/src/pages/government/barangays/index.tsx
+++ b/src/pages/government/barangays/index.tsx
@@ -1,4 +1,5 @@
 import { MapPinIcon, User2 } from 'lucide-react';
+import SEO from '@/components/SEO';
 import { PageHero } from '@/components/layout/PageLayouts';
 import { Heading } from '@/components/ui/Heading';
 import { Text } from '@/components/ui/Text';
@@ -17,6 +18,11 @@ export default function BarangaysIndex() {
       className="mx-auto max-w-7xl px-4 py-6 md:px-8 lg:px-12"
       aria-label="Barangays directory"
     >
+      <SEO
+        title="Barangays"
+        description={`Browse the ${sortedBarangays.length} component barangays of the municipality, including officials and contact information.`}
+        keywords="barangays, local government units, community, municipal subdivisions"
+      />
       <PageHero
         title="Local Barangays"
         description={`${sortedBarangays.length} component barangays of the municipality.`}

--- a/src/pages/government/elected-officials/MunicipalCommittees.tsx
+++ b/src/pages/government/elected-officials/MunicipalCommittees.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import SEO from '../../../components/SEO';
 import { Heading } from '../../../components/ui/Heading';
 import { Text } from '../../../components/ui/Text';
 import {
@@ -78,6 +79,11 @@ export default function MunicipalCommitteesPage() {
 
   return (
     <main className="p-4 md:p-6" aria-label="Municipal committees directory">
+      <SEO
+        title="Municipal Committees"
+        description="Active standing committees of the Sangguniang Bayan, including chairpersons and member assignments."
+        keywords="municipal committees, sangguniang bayan, local legislation, committee assignments"
+      />
       {/* Header */}
       <div className="text-center mb-6 md:mb-8">
         <Heading level={2}>Committees</Heading>


### PR DESCRIPTION
### Summary

Fixes blank link previews on Facebook, Twitter, LinkedIn when sharing pages deeper than /.
- Creates scripts/generate-og-manifest.js — maps all 129 routes to {title, description} from YAML + markdown content
- Creates functions/_middleware.ts — Cloudflare Pages Function injects og:title, og:description, og:image, og:url, twitter:card into <head> via HTMLRewriter before crawlers see the page
- Wires manifest generation into npm run build
- Fixes tourism category page rendering (was showing "not found" instead of places)
- Adds missing <SEO> on MunicipalCommittees and Barangays pages
- Fixes og:url to be dynamic per-page and OG image fallback to use actual .webp file